### PR TITLE
Add possibility to calibrate rudder, depending on if the Eel pulls to the left or right in real life

### DIFF
--- a/src/eel/eel/gnss/gnss_node.py
+++ b/src/eel/eel/gnss/gnss_node.py
@@ -4,10 +4,8 @@ from rclpy.node import Node
 from eel_interfaces.msg import GnssStatus
 from .gnss_sensor import GnssSensor
 from .gnss_sim import GnssSimulator
-
-GNSS_STATUS_TOPIC = "/gnss_status"
-SIMULATE_PARAM = "simulate"
-DEBUG_PARAM = "debug"
+from ..utils.constants import SIMULATE_PARAM
+from ..utils.topics import GNSS_STATUS
 
 # hertz (updates per second)
 UPDATE_FREQUENCY = 10
@@ -16,11 +14,9 @@ UPDATE_FREQUENCY = 10
 class GNSS(Node):
     def __init__(self):
         super().__init__("gnss_node")
-        self.publisher = self.create_publisher(GnssStatus, GNSS_STATUS_TOPIC, 10)
+        self.publisher = self.create_publisher(GnssStatus, GNSS_STATUS, 10)
         self.declare_parameter(SIMULATE_PARAM, False)
         self.should_simulate = self.get_parameter(SIMULATE_PARAM).value
-        self.declare_parameter(DEBUG_PARAM, False)
-        self.debug = self.get_parameter(DEBUG_PARAM).value
 
         if not self.should_simulate:
             sensor = GnssSensor()
@@ -36,9 +32,6 @@ class GNSS(Node):
 
     def publish(self):
         lat, lon = self.get_current_position()
-
-        if self.debug:
-            self.get_logger().info("lat: {}, lon: {}".format(lat, lon))
 
         if isinstance(lat, float) and isinstance(lon, float):
             msg = GnssStatus()

--- a/src/eel/eel/gnss/gnss_sim.py
+++ b/src/eel/eel/gnss/gnss_sim.py
@@ -3,9 +3,7 @@ from std_msgs.msg import Float32
 from geopy import distance
 from eel_interfaces.msg import ImuStatus
 from ..utils.sim import LINEAR_VELOCITY
-
-MOTOR_TOPIC = "motor"
-IMU_STATUS_TOPIC = "imu_status"
+from ..utils.topics import MOTOR_CMD, IMU_STATUS
 
 
 def calculate_position_delta(velocity_in_mps, time_in_s):
@@ -20,10 +18,10 @@ class GnssSimulator:
         self.current_position = {"lat": 59.309406850903784, "lon": 17.9742443561554}
 
         self.motor_subscription = parent_node.create_subscription(
-            Float32, MOTOR_TOPIC, self._handle_motor_msg, 10
+            Float32, MOTOR_CMD, self._handle_motor_msg, 10
         )
         self.imu_subscription = parent_node.create_subscription(
-            ImuStatus, IMU_STATUS_TOPIC, self._handle_imu_msg, 10
+            ImuStatus, IMU_STATUS, self._handle_imu_msg, 10
         )
 
     def _handle_motor_msg(self, msg):

--- a/src/eel/eel/imu/imu_node.py
+++ b/src/eel/eel/imu/imu_node.py
@@ -4,9 +4,8 @@ from rclpy.node import Node
 from eel_interfaces.msg import ImuStatus
 from .imu_sensor import ImuSensor
 from .imu_sim import ImuSimulator
-
-IMU_STATUS_TOPIC = "/imu_status"
-SIMULATE_PARAM = "simulate"
+from ..utils.constants import SIMULATE_PARAM
+from ..utils.topics import IMU_STATUS
 
 # hertz (publications per second)
 UPDATE_FREQUENCY = 10
@@ -17,7 +16,7 @@ class ImuNode(Node):
         super().__init__("imu_node")
         self.declare_parameter(SIMULATE_PARAM, False)
         self.should_simulate = self.get_parameter(SIMULATE_PARAM).value
-        self.status_publisher = self.create_publisher(ImuStatus, IMU_STATUS_TOPIC, 10)
+        self.status_publisher = self.create_publisher(ImuStatus, IMU_STATUS, 10)
 
         if not self.should_simulate:
             sensor = ImuSensor()

--- a/src/eel/eel/imu/imu_sim.py
+++ b/src/eel/eel/imu/imu_sim.py
@@ -1,9 +1,7 @@
 from time import time
 from std_msgs.msg import Float32
 from ..utils.sim import ANGULAR_VELOCITY
-
-RUDDER_TOPIC = "rudder"
-MOTOR_TOPIC = "motor"
+from ..utils.topics import RUDDER_STATUS, MOTOR_CMD
 
 
 def calculate_angle_delta(angular_velocity, time_in_s):
@@ -17,10 +15,10 @@ class ImuSimulator:
         self.speed = 0
         self.last_updated_at = time()
         self.rudder_subscription = parent_node.create_subscription(
-            Float32, RUDDER_TOPIC, self._handle_rudder_msg, 10
+            Float32, RUDDER_STATUS, self._handle_rudder_msg, 10
         )
         self.motor_subscription = parent_node.create_subscription(
-            Float32, MOTOR_TOPIC, self._handle_motor_msg, 10
+            Float32, MOTOR_CMD, self._handle_motor_msg, 10
         )
 
     def _handle_rudder_msg(self, msg):

--- a/src/eel/eel/motor/motor_node.py
+++ b/src/eel/eel/motor/motor_node.py
@@ -3,10 +3,8 @@ import rclpy
 from rclpy.node import Node
 from std_msgs.msg import Float32
 from .motor_sim import MotorSimulator
-
-
-MOTOR_TOPIC = "motor"
-SIMULATE_PARAM = "simulate"
+from ..utils.topics import MOTOR_CMD
+from ..utils.constants import SIMULATE_PARAM
 
 
 def clamp(value, minimum, maximum):
@@ -25,7 +23,7 @@ class Motor(Node):
         self.should_simulate = self.get_parameter(SIMULATE_PARAM).value
 
         self.motor_subscription = self.create_subscription(
-            Float32, MOTOR_TOPIC, self.handle_motor_msg, 10
+            Float32, MOTOR_CMD, self.handle_motor_msg, 10
         )
 
         if self.should_simulate:

--- a/src/eel/eel/navigation/navigation_node.py
+++ b/src/eel/eel/navigation/navigation_node.py
@@ -8,11 +8,7 @@ from ..utils.nav import (
     get_relative_bearing_in_degrees,
     get_closest_turn_direction,
 )
-
-GNSS_STATUS_TOPIC = "gnss_status"
-IMU_STATUS_TOPIC = "imu_status"
-MOTOR_TOPIC = "motor"
-RUDDER_TOPIC = "rudder"
+from ..utils.topics import RUDDER_CMD, MOTOR_CMD, IMU_STATUS, GNSS_STATUS
 
 
 class NavigationNode(Node):
@@ -34,14 +30,14 @@ class NavigationNode(Node):
         self.current_heading = 0.0
 
         self.gnss_subscription = self.create_subscription(
-            GnssStatus, GNSS_STATUS_TOPIC, self.handle_gnss_update, 10
+            GnssStatus, GNSS_STATUS, self.handle_gnss_update, 10
         )
         self.imu_subscription = self.create_subscription(
-            ImuStatus, IMU_STATUS_TOPIC, self.handle_imu_update, 10
+            ImuStatus, IMU_STATUS, self.handle_imu_update, 10
         )
 
-        self.motor_publisher = self.create_publisher(Float32, MOTOR_TOPIC, 10)
-        self.rudder_publisher = self.create_publisher(Float32, RUDDER_TOPIC, 10)
+        self.motor_publisher = self.create_publisher(Float32, MOTOR_CMD, 10)
+        self.rudder_publisher = self.create_publisher(Float32, RUDDER_CMD, 10)
 
     def handle_imu_update(self, msg):
         self.current_heading = msg.euler_heading

--- a/src/eel/eel/radio/radio_node.py
+++ b/src/eel/eel/radio/radio_node.py
@@ -5,14 +5,16 @@ import json
 from eel_interfaces.msg import GnssStatus, ImuStatus
 from std_msgs.msg import String, Float32
 from ..utils.serial_helpers import SerialReaderWriter
+from ..utils.topics import (
+    RUDDER_CMD,
+    MOTOR_CMD,
+    IMU_STATUS,
+    GNSS_STATUS,
+    RADIO_IN,
+    RADIO_OUT,
+)
+from ..utils.constants import SIMULATE_PARAM
 
-IMU_STATUS_TOPIC = "imu_status"
-GNSS_STATUS_TOPIC = "gnss_status"
-RADIO_OUT_TOPIC = "radio_out"
-RADIO_IN_TOPIC = "radio_in"
-RUDDER_TOPIC = "rudder"
-MOTOR_TOPIC = "motor"
-SIMULATE_PARAM = "simulate"
 
 RUDDER_KEY = "rudder"
 MOTOR_KEY = "motor"
@@ -37,16 +39,16 @@ class Radio(Node):
         self.send_timer = self.create_timer(1.0, self.send_state)
 
         self.imu_subscription = self.create_subscription(
-            ImuStatus, IMU_STATUS_TOPIC, self.handle_imu_update, 10
+            ImuStatus, IMU_STATUS, self.handle_imu_update, 10
         )
         self.gnss_subscription = self.create_subscription(
-            GnssStatus, GNSS_STATUS_TOPIC, self.handle_gnss_update, 10
+            GnssStatus, GNSS_STATUS, self.handle_gnss_update, 10
         )
 
-        self.radio_out_publisher = self.create_publisher(String, RADIO_OUT_TOPIC, 10)
-        self.radio_in_publisher = self.create_publisher(String, RADIO_IN_TOPIC, 10)
-        self.rudder_publisher = self.create_publisher(Float32, RUDDER_TOPIC, 10)
-        self.motor_publisher = self.create_publisher(Float32, MOTOR_TOPIC, 10)
+        self.radio_out_publisher = self.create_publisher(String, RADIO_OUT, 10)
+        self.radio_in_publisher = self.create_publisher(String, RADIO_IN, 10)
+        self.rudder_publisher = self.create_publisher(Float32, RUDDER_CMD, 10)
+        self.motor_publisher = self.create_publisher(Float32, MOTOR_CMD, 10)
 
         serial_port = (
             "/tmp/virtual_serial_eel" if self.should_simulate else "/dev/ttyS0"

--- a/src/eel/eel/rudder/rudder_node.py
+++ b/src/eel/eel/rudder/rudder_node.py
@@ -6,10 +6,8 @@ from std_msgs.msg import Float32
 import sys
 from .rudder_servo import RudderServo
 from .rudder_sim import RudderSimulator
-
-
-RUDDER_TOPIC = "rudder"
-SIMULATE_PARAM = "simulate"
+from ..utils.topics import RUDDER_CMD, RUDDER_STATUS
+from ..utils.constants import SIMULATE_PARAM
 
 
 def clamp(value, minimum, maximum):
@@ -27,8 +25,8 @@ class Rudder(Node):
 
         self.declare_parameter(SIMULATE_PARAM, False)
         self.should_simulate = self.get_parameter(SIMULATE_PARAM).value
-        self.rudder_subscription = self.create_subscription(
-            Float32, RUDDER_TOPIC, self.handle_rudder_msg, 10
+        self.rudder_cmd_subscription = self.create_subscription(
+            Float32, RUDDER_CMD, self.handle_rudder_msg, 10
         )
         if self.should_simulate:
             simulator = RudderSimulator()

--- a/src/eel/eel/utils/constants.py
+++ b/src/eel/eel/utils/constants.py
@@ -1,0 +1,1 @@
+SIMULATE_PARAM = "simulate"

--- a/src/eel/eel/utils/topics.py
+++ b/src/eel/eel/utils/topics.py
@@ -1,0 +1,16 @@
+# Rudder
+RUDDER_STATUS = "rudder/status"
+RUDDER_CMD = "rudder/cmd"
+
+# Motor
+MOTOR_CMD = "motor/cmd"
+
+# GNSS
+GNSS_STATUS = "gnss/status"
+
+# IMU
+IMU_STATUS = "imu/status"
+
+# Radio
+RADIO_IN = "radio/in"
+RADIO_OUT = "radio/out"


### PR DESCRIPTION
## Changes
- Add two variables (one for simulation and one for regular runs) to be able to calibrate the centering of the rudder. The spinning propeller might cause the whole thing to pull to the left or right. So, we can set that value when we have tested it.
- Remove obsolete `debug` flag from GNSS
- Rename topics to `rudder/cmd` and `rudder/status` and similar. The advantage is that when inspecting in `rqt_graph` the two topics get grouped, which I guess is nice.
- Move all topic names to separate file, since they were recreated in a lot of places. 