### PR TITLE
Feat/toggle auto mode

### DIFF
--- a/src/eel/eel/gnss/gnss_node.py
+++ b/src/eel/eel/gnss/gnss_node.py
@@ -7,13 +7,14 @@ from .gnss_sim import GnssSimulator
 from ..utils.constants import SIMULATE_PARAM
 from ..utils.topics import GNSS_STATUS
 
-# hertz (updates per second)
-UPDATE_FREQUENCY = 5
-
 
 class GNSS(Node):
     def __init__(self):
         super().__init__("gnss_node")
+
+        # hertz (updates per second)
+        self.update_frequency = 5
+
         self.publisher = self.create_publisher(GnssStatus, GNSS_STATUS, 10)
         self.declare_parameter(SIMULATE_PARAM, False)
         self.should_simulate = self.get_parameter(SIMULATE_PARAM).value
@@ -25,7 +26,7 @@ class GNSS(Node):
             simulator = GnssSimulator(self)
             self.get_current_position = simulator.get_current_position
 
-        self.poller = self.create_timer(1.0 / UPDATE_FREQUENCY, self.publish)
+        self.poller = self.create_timer(1.0 / self.update_frequency, self.publish)
         self.get_logger().info(
             "{}GNSS node started.".format("SIMULATE " if self.should_simulate else "")
         )

--- a/src/eel/eel/gnss/gnss_sim.py
+++ b/src/eel/eel/gnss/gnss_sim.py
@@ -24,13 +24,15 @@ class GnssSimulator:
             ImuStatus, IMU_STATUS, self._handle_imu_msg, 10
         )
 
+        self.gnss_updater = parent_node.create_timer(
+            1.0 / (parent_node.update_frequency * 2), self._update_position
+        )
+
     def _handle_motor_msg(self, msg):
         self.speed = msg.data
-        self._update_position()
 
     def _handle_imu_msg(self, msg):
         self.current_heading = msg.euler_heading
-        self._update_position()
 
     def _update_position(self):
         if self.speed > 0:

--- a/src/eel/eel/imu/imu_node.py
+++ b/src/eel/eel/imu/imu_node.py
@@ -7,9 +7,6 @@ from .imu_sim import ImuSimulator
 from ..utils.constants import SIMULATE_PARAM
 from ..utils.topics import IMU_STATUS
 
-# hertz (publications per second)
-UPDATE_FREQUENCY = 5
-
 
 class ImuNode(Node):
     def __init__(self):
@@ -17,6 +14,9 @@ class ImuNode(Node):
         self.declare_parameter(SIMULATE_PARAM, False)
         self.should_simulate = self.get_parameter(SIMULATE_PARAM).value
         self.status_publisher = self.create_publisher(ImuStatus, IMU_STATUS, 10)
+
+        # hertz (publications per second)
+        self.update_frequency = 5
 
         if not self.should_simulate:
             sensor = ImuSensor()
@@ -30,7 +30,7 @@ class ImuNode(Node):
             self.get_calibration_status = simulator.get_calibration_status
             self.get_is_calibrated = simulator.get_is_calibrated
 
-        self.updater = self.create_timer(1.0 / UPDATE_FREQUENCY, self.publish_imu)
+        self.updater = self.create_timer(1.0 / self.update_frequency, self.publish_imu)
 
         self.get_logger().info(
             "{}IMU node started.".format("SIMULATE " if self.should_simulate else "")

--- a/src/eel/eel/imu/imu_sim.py
+++ b/src/eel/eel/imu/imu_sim.py
@@ -21,13 +21,15 @@ class ImuSimulator:
             Float32, MOTOR_CMD, self._handle_motor_msg, 10
         )
 
+        self.imu_updater = parent_node.create_timer(
+            1.0 / (parent_node.update_frequency * 2), self._update_imu
+        )
+
     def _handle_rudder_msg(self, msg):
         self.current_rudder_status = msg.data
-        self._update_imu()
 
     def _handle_motor_msg(self, msg):
         self.speed = msg.data
-        self._update_imu()
 
     def _update_imu(self):
         if self.speed > 0:

--- a/src/eel/eel/navigation/navigation_node.py
+++ b/src/eel/eel/navigation/navigation_node.py
@@ -6,7 +6,7 @@ from std_msgs.msg import Float32, Bool
 from ..utils.nav import (
     get_distance_in_meters,
     get_relative_bearing_in_degrees,
-    get_closest_turn_direction,
+    get_next_rudder_turn,
 )
 from ..utils.topics import (
     RUDDER_CMD,
@@ -18,22 +18,6 @@ from ..utils.topics import (
 )
 
 TOLERANCE_IN_METERS = 5.0
-
-
-def get_next_rudder_turn(current_heading, target_heading):
-    closest_angle_offset = abs(target_heading - current_heading) % 360
-    closest_angle_offset = (
-        360 - closest_angle_offset
-        if closest_angle_offset > 180
-        else closest_angle_offset
-    )
-
-    proportional_offset = closest_angle_offset / 180.0
-    rudder_adjustment = (
-        1 if abs(proportional_offset) > 0.1 else (proportional_offset * 3)
-    )
-    direction = get_closest_turn_direction(current_heading, target_heading)
-    return rudder_adjustment * direction
 
 
 class NavigationNode(Node):

--- a/src/eel/eel/navigation/navigation_node.py
+++ b/src/eel/eel/navigation/navigation_node.py
@@ -48,7 +48,7 @@ class NavigationNode(Node):
         self.current_position = {"lat": None, "long": None}
         self.target = self._travel_plan[self.position_index]
 
-        self.distance_to_target = 9999999999.0
+        self.distance_to_target = 0.0
         self.bearing_to_target = 0.0
 
         self.current_heading = 0.0
@@ -81,6 +81,7 @@ class NavigationNode(Node):
 
     def publish_nav_status(self):
         nav_msg = NavigationStatus()
+        nav_msg.auto_mode_enabled = self.should_navigate
         nav_msg.next_target = []
         if self.target:
             nav_msg.meters_to_target = self.distance_to_target

--- a/src/eel/eel/navigation/navigation_node.py
+++ b/src/eel/eel/navigation/navigation_node.py
@@ -68,6 +68,15 @@ class NavigationNode(Node):
             "lat": msg.lat,
             "lon": msg.lon,
         }
+
+        if self.target:
+            self.distance_to_target = get_distance_in_meters(
+                self.current_position["lat"],
+                self.current_position["lon"],
+                self.target["lat"],
+                self.target["lon"],
+            )
+
         if self.should_navigate and self.target:
             self.go_towards_target()
 
@@ -110,12 +119,6 @@ class NavigationNode(Node):
             self.target = None
 
     def go_towards_target(self):
-        self.distance_to_target = get_distance_in_meters(
-            self.current_position["lat"],
-            self.current_position["lon"],
-            self.target["lat"],
-            self.target["lon"],
-        )
         target_reached = self.distance_to_target < TOLERANCE_IN_METERS
         if target_reached:
             self.update_target()

--- a/src/eel/eel/radio/radio_node.py
+++ b/src/eel/eel/radio/radio_node.py
@@ -35,7 +35,8 @@ class Radio(Node):
             "magnetometer": 0,
             "lat": 0,
             "lon": 0,
-            "next_target": None,
+            "nextTarget": None,
+            "autoModeEnabled": None,
         }
 
         self.send_timer = self.create_timer(1.0, self.send_state)
@@ -159,16 +160,14 @@ class Radio(Node):
 
     def handle_nav_update(self, nav_msg):
         next_target = None
-        if len(nav_msg.next_target) > 0:
+        if len(nav_msg.next_target) > 0 and nav_msg.auto_mode_enabled:
             coordinate = nav_msg.next_target[0]
             next_target = {
                 "coordinate": {"lat": coordinate.lat, "lon": coordinate.lon},
                 "distance": nav_msg.meters_to_target,
                 "tolerance": nav_msg.tolerance_in_meters,
             }
-        data = {
-            "nextTarget": next_target,
-        }
+        data = {"nextTarget": next_target, "autoModeEnabled": nav_msg.auto_mode_enabled}
         self.update_state(data)
 
 

--- a/src/eel/eel/radio/radio_node.py
+++ b/src/eel/eel/radio/radio_node.py
@@ -2,9 +2,15 @@
 import rclpy
 from rclpy.node import Node
 import json
+from types import SimpleNamespace
 from eel_interfaces.msg import GnssStatus, ImuStatus, NavigationStatus
 from std_msgs.msg import String, Float32, Bool
 from ..utils.serial_helpers import SerialReaderWriter
+from ..utils.radio_helpers.eel_side import (
+    EelState,
+    from_json_to_command,
+    from_state_to_json,
+)
 from ..utils.topics import (
     RUDDER_CMD,
     MOTOR_CMD,
@@ -23,35 +29,145 @@ MOTOR_KEY = "motor"
 NAV_KEY = "nav"
 AUTO_MODE_KEY = "enable_auto_mode"
 
+UPDATE_FREQUENCY = 1
+
+
+def from_json(data):
+    return json.loads(data, object_hook=lambda d: SimpleNamespace(**d))
+
+
+# data = '{"name": "John Smith", "hometown": {"name": "New York", "id": 123}}'
+
+# # Parse JSON into an object with attributes corresponding to dict keys.
+# x = json.loads(data, object_hook=lambda d: SimpleNamespace(**d))
+# print(x.name, x.hometown.name, x.hometown.id)
+
+
+class RadioOutMessage:
+    def set_position(self, position):
+        self.position = position
+
+    def set_imu_state(self, imu_state):
+        self.imuState = imu_state
+
+    def to_json(self):
+        return json.dumps(self, default=lambda o: o.__dict__)
+
+
+class Bar(object):
+    def __init__(self, **kwargs):
+        allowed_keys = {"a", "b", "c"}
+        self.__dict__.update((k, v) for k, v in kwargs.items() if k in allowed_keys)
+        # self.__dict__.update(kwargs)
+
+
+# NOTE: keys are in camelcase to make them pretty in json
+class ImuState:
+    def __init__(self) -> None:
+        self.c = False  # is calibrated
+        self.s = 0  # system calibration value
+        self.g = 0  # gyro calibration value
+        self.a = 0  # accelerometer calibration value
+        self.m = 0  # magnetometer calibration value
+        self.h = None  # heading
+
+    # def set_imu_state(self, imu_state):
+    #     pass
+
+    # def to_json(self):
+    #     pass
+
+    def is_valid(self):
+        return True
+
+
+class Position:
+    def __init__(self) -> None:
+        self.lt = None  # latitude
+        self.ln = None  # longitude
+
+    def is_valid(self):
+        return self.lt and self.ln and self.lt != 0 and self.ln != 0
+
+
+class NavState:
+    def __init__(self) -> None:
+        self.c = Position()  # target coordinate
+        self.d = None  # distance to target
+        self.t = None  # target tolerance
+        self.a = None  # is auto mode enabled
+
+    def is_valid(self):
+        return True
+
+
+class State:
+    def __init__(self) -> None:
+        self.p = Position()  # position
+        self.n = NavState()  # navigation state
+        self.i = ImuState()  # imu state
+
+    def update_imu(self, msg):
+        self.i.c = msg.is_calibrated
+        self.i.s = msg.sys
+        self.i.g = msg.gyro
+        self.i.a = msg.accel
+        self.i.m = msg.mag
+        self.i.h = msg.euler_heading
+
+    def update_position(self, msg):
+        self.p.lt = msg.lat
+        self.p.ln = msg.lon
+
+    def update_nav(self, msg):
+        if len(msg.next_target) > 0:
+            next_target = msg.next_target[0]
+            self.n.c.lt = next_target.lat
+            self.n.c.ln = next_target.lon
+            self.n.d = msg.meters_to_target
+            self.n.t = msg.tolerance_in_meters
+        else:
+            self.n.c = Position()
+            self.n.d = None
+            self.n.t = None
+
+        self.n.a = msg.auto_mode_enabled
+
+    def to_json(self):
+        # only_set_keys = {k: v for k, v in self.__dict__.items() if v is not None}
+        # return json.dumps(only_set_keys)
+
+        valid_keys = {
+            k: v
+            for k, v in self.__dict__.items()
+            # if not hasattr(v, "is_valid") or v.is_valid()
+            if v.is_valid()
+            # if k == "position"
+        }
+
+        # return json.dumps(self, default=lambda o: o.__dict__)
+        # return json.dumps(valid_keys, default=lambda o: o.__dict__)
+        return json.dumps(valid_keys, default=lambda o: o.__dict__)
+
 
 class Radio(Node):
     def __init__(self):
         super().__init__("radio_node")
         self.declare_parameter(SIMULATE_PARAM, False)
         self.should_simulate = self.get_parameter(SIMULATE_PARAM).value
-        self.state = {
-            "heading": 0,
-            "isCalibrated": False,
-            "system": 0,
-            "gyro": 0,
-            "accelerometer": 0,
-            "magnetometer": 0,
-            "lat": 0,
-            "lon": 0,
-            "nextTarget": None,
-            "autoModeEnabled": None,
-        }
 
-        self.send_timer = self.create_timer(1.0, self.send_state)
+        self.state = EelState()
+
+        self.sender = self.create_timer(1.0 / UPDATE_FREQUENCY, self.send_state)
 
         self.imu_subscription = self.create_subscription(
-            ImuStatus, IMU_STATUS, self.handle_imu_update, 10
+            ImuStatus, IMU_STATUS, self.state.update_imu, 10
         )
         self.gnss_subscription = self.create_subscription(
-            GnssStatus, GNSS_STATUS, self.handle_gnss_update, 10
+            GnssStatus, GNSS_STATUS, self.state.update_gnss, 10
         )
         self.nav_subscription = self.create_subscription(
-            NavigationStatus, NAVIGATION_STATUS, self.handle_nav_update, 10
+            NavigationStatus, NAVIGATION_STATUS, self.state.update_nav, 10
         )
 
         self.radio_out_publisher = self.create_publisher(String, RADIO_OUT, 10)
@@ -75,6 +191,7 @@ class Radio(Node):
 
     def send(self, message=None):
         if message:
+            # self.get_logger().info(message)
             self.reader_writer.send(message)
             radio_out_msg = String()
             radio_out_msg.data = message
@@ -89,14 +206,33 @@ class Radio(Node):
         # return False
         # return True
 
+    # TODO: Either we validate the state kind of like this, or perhaps
+    # we have a state variable that determines if the state has changed.
+    # Or something else. In any case, this prevents the initial zeros
+    # from being sent.
+    def should_send_position(self):
+        return (
+            self.current_position
+            and self.current_position.get("lat") != 0
+            and self.current_position.get("lon") != 0
+        )
+        # return self.state.get("lat") != 0 and self.state.get("lon") != 0
+        # return False
+        # return True
+
     def send_state(self):
-        if self.should_send_state():
-            self.send(message=json.dumps(self.state))
+        # if self.should_send_state():
+        #     self.send(message=json.dumps(self.state))
 
-    def update_state(self, data):
-        self.state = {**self.state, **data}
+        # self.get_logger().info(self.state.t)
 
-    def handle_incoming_message(self, message):
+        # self.send(message=self.state.to_json())
+        self.send(message=from_state_to_json(self.state))
+
+    # def update_state(self, data):
+    #     self.state = {**self.state, **data}
+
+    def handle_incoming_message2(self, message):
         radio_in_msg = String()
         radio_in_msg.data = message
         self.radio_in_publisher.publish(radio_in_msg)
@@ -118,30 +254,47 @@ class Radio(Node):
             if data.get(NAV_KEY) is not None:
                 self.handle_nav_radio_msg(data.get(NAV_KEY))
 
-    def handle_nav_radio_msg(self, msg):
+    def handle_incoming_message(self, message):
+        self.get_logger().info(message)
+        radio_in_msg = String()
+        radio_in_msg.data = message
+        self.radio_in_publisher.publish(radio_in_msg)
+        data = None
+        cmd = from_json_to_command(message)
+        self.get_logger().info("haha" + str(cmd))
+        if cmd.r != None:
+            self.handle_rudder_msg(cmd.r)
+        if cmd.m != None:
+            self.handle_motor_msg(cmd.m)
+        if cmd.a != None:
+            self.handle_nav_radio_msg(cmd.a)
+        # try:
+        #     data = json.loads(message)
+        # except:
+        #     self.get_logger().warning(
+        #         "Could not parse json, incoming radio message: {}".format(message)
+        #     )
+
+        # if data:
+        #     if data.get(RUDDER_KEY) is not None:
+        #         self.handle_rudder_msg(data.get(RUDDER_KEY))
+
+        #     if data.get(MOTOR_KEY) is not None:
+        #         self.handle_motor_msg(data.get(MOTOR_KEY))
+
+        #     if data.get(NAV_KEY) is not None:
+        #         self.handle_nav_radio_msg(data.get(NAV_KEY))
+
+    def handle_nav_radio_msg(self, auto_mode_enabled):
+        nav_msg = Bool()
+        nav_msg.data = bool(auto_mode_enabled)
+        self.nav_publisher.publish(nav_msg)
+
+    def handle_nav_radio_msg2(self, msg):
         if msg.get(AUTO_MODE_KEY) is not None:
             nav_msg = Bool()
             nav_msg.data = bool(msg.get(AUTO_MODE_KEY))
             self.nav_publisher.publish(nav_msg)
-
-    def handle_imu_update(self, msg):
-        data = {
-            "heading": msg.euler_heading,
-            "isCalibrated": msg.is_calibrated,
-            "system": msg.sys,
-            "gyro": msg.gyro,
-            "accelerometer": msg.accel,
-            "magnetometer": msg.mag,
-        }
-        self.update_state(data)
-
-    def handle_gnss_update(self, msg):
-        data = {
-            "lat": msg.lat,
-            "lon": msg.lon,
-        }
-
-        self.update_state(data)
 
     def handle_rudder_msg(self, rudder_msg_value):
         rudder_value = None
@@ -181,7 +334,7 @@ class Radio(Node):
                 "tolerance": nav_msg.tolerance_in_meters,
             }
         data = {"nextTarget": next_target, "autoModeEnabled": nav_msg.auto_mode_enabled}
-        self.update_state(data)
+        # self.update_state(data)
 
 
 def main(args=None):

--- a/src/eel/eel/radio/radio_node.py
+++ b/src/eel/eel/radio/radio_node.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 import rclpy
 from rclpy.node import Node
-import json
-from types import SimpleNamespace
 from eel_interfaces.msg import GnssStatus, ImuStatus, NavigationStatus
 from std_msgs.msg import String, Float32, Bool
 from ..utils.serial_helpers import SerialReaderWriter
@@ -24,130 +22,7 @@ from ..utils.topics import (
 from ..utils.constants import SIMULATE_PARAM
 
 
-RUDDER_KEY = "rudder"
-MOTOR_KEY = "motor"
-NAV_KEY = "nav"
-AUTO_MODE_KEY = "enable_auto_mode"
-
 UPDATE_FREQUENCY = 1
-
-
-def from_json(data):
-    return json.loads(data, object_hook=lambda d: SimpleNamespace(**d))
-
-
-# data = '{"name": "John Smith", "hometown": {"name": "New York", "id": 123}}'
-
-# # Parse JSON into an object with attributes corresponding to dict keys.
-# x = json.loads(data, object_hook=lambda d: SimpleNamespace(**d))
-# print(x.name, x.hometown.name, x.hometown.id)
-
-
-class RadioOutMessage:
-    def set_position(self, position):
-        self.position = position
-
-    def set_imu_state(self, imu_state):
-        self.imuState = imu_state
-
-    def to_json(self):
-        return json.dumps(self, default=lambda o: o.__dict__)
-
-
-class Bar(object):
-    def __init__(self, **kwargs):
-        allowed_keys = {"a", "b", "c"}
-        self.__dict__.update((k, v) for k, v in kwargs.items() if k in allowed_keys)
-        # self.__dict__.update(kwargs)
-
-
-# NOTE: keys are in camelcase to make them pretty in json
-class ImuState:
-    def __init__(self) -> None:
-        self.c = False  # is calibrated
-        self.s = 0  # system calibration value
-        self.g = 0  # gyro calibration value
-        self.a = 0  # accelerometer calibration value
-        self.m = 0  # magnetometer calibration value
-        self.h = None  # heading
-
-    # def set_imu_state(self, imu_state):
-    #     pass
-
-    # def to_json(self):
-    #     pass
-
-    def is_valid(self):
-        return True
-
-
-class Position:
-    def __init__(self) -> None:
-        self.lt = None  # latitude
-        self.ln = None  # longitude
-
-    def is_valid(self):
-        return self.lt and self.ln and self.lt != 0 and self.ln != 0
-
-
-class NavState:
-    def __init__(self) -> None:
-        self.c = Position()  # target coordinate
-        self.d = None  # distance to target
-        self.t = None  # target tolerance
-        self.a = None  # is auto mode enabled
-
-    def is_valid(self):
-        return True
-
-
-class State:
-    def __init__(self) -> None:
-        self.p = Position()  # position
-        self.n = NavState()  # navigation state
-        self.i = ImuState()  # imu state
-
-    def update_imu(self, msg):
-        self.i.c = msg.is_calibrated
-        self.i.s = msg.sys
-        self.i.g = msg.gyro
-        self.i.a = msg.accel
-        self.i.m = msg.mag
-        self.i.h = msg.euler_heading
-
-    def update_position(self, msg):
-        self.p.lt = msg.lat
-        self.p.ln = msg.lon
-
-    def update_nav(self, msg):
-        if len(msg.next_target) > 0:
-            next_target = msg.next_target[0]
-            self.n.c.lt = next_target.lat
-            self.n.c.ln = next_target.lon
-            self.n.d = msg.meters_to_target
-            self.n.t = msg.tolerance_in_meters
-        else:
-            self.n.c = Position()
-            self.n.d = None
-            self.n.t = None
-
-        self.n.a = msg.auto_mode_enabled
-
-    def to_json(self):
-        # only_set_keys = {k: v for k, v in self.__dict__.items() if v is not None}
-        # return json.dumps(only_set_keys)
-
-        valid_keys = {
-            k: v
-            for k, v in self.__dict__.items()
-            # if not hasattr(v, "is_valid") or v.is_valid()
-            if v.is_valid()
-            # if k == "position"
-        }
-
-        # return json.dumps(self, default=lambda o: o.__dict__)
-        # return json.dumps(valid_keys, default=lambda o: o.__dict__)
-        return json.dumps(valid_keys, default=lambda o: o.__dict__)
 
 
 class Radio(Node):
@@ -191,150 +66,42 @@ class Radio(Node):
 
     def send(self, message=None):
         if message:
-            # self.get_logger().info(message)
             self.reader_writer.send(message)
             radio_out_msg = String()
             radio_out_msg.data = message
             self.radio_out_publisher.publish(radio_out_msg)
 
-    # TODO: Either we validate the state kind of like this, or perhaps
-    # we have a state variable that determines if the state has changed.
-    # Or something else. In any case, this prevents the initial zeros
-    # from being sent.
-    def should_send_state(self):
-        return self.state.get("lat") != 0 and self.state.get("lon") != 0
-        # return False
-        # return True
-
-    # TODO: Either we validate the state kind of like this, or perhaps
-    # we have a state variable that determines if the state has changed.
-    # Or something else. In any case, this prevents the initial zeros
-    # from being sent.
-    def should_send_position(self):
-        return (
-            self.current_position
-            and self.current_position.get("lat") != 0
-            and self.current_position.get("lon") != 0
-        )
-        # return self.state.get("lat") != 0 and self.state.get("lon") != 0
-        # return False
-        # return True
-
     def send_state(self):
-        # if self.should_send_state():
-        #     self.send(message=json.dumps(self.state))
-
-        # self.get_logger().info(self.state.t)
-
-        # self.send(message=self.state.to_json())
         self.send(message=from_state_to_json(self.state))
 
-    # def update_state(self, data):
-    #     self.state = {**self.state, **data}
-
-    def handle_incoming_message2(self, message):
-        radio_in_msg = String()
-        radio_in_msg.data = message
-        self.radio_in_publisher.publish(radio_in_msg)
-        data = None
-        try:
-            data = json.loads(message)
-        except:
-            self.get_logger().warning(
-                "Could not parse json, incoming radio message: {}".format(message)
-            )
-
-        if data:
-            if data.get(RUDDER_KEY) is not None:
-                self.handle_rudder_msg(data.get(RUDDER_KEY))
-
-            if data.get(MOTOR_KEY) is not None:
-                self.handle_motor_msg(data.get(MOTOR_KEY))
-
-            if data.get(NAV_KEY) is not None:
-                self.handle_nav_radio_msg(data.get(NAV_KEY))
-
     def handle_incoming_message(self, message):
-        self.get_logger().info(message)
         radio_in_msg = String()
         radio_in_msg.data = message
         self.radio_in_publisher.publish(radio_in_msg)
-        data = None
         cmd = from_json_to_command(message)
-        self.get_logger().info("haha" + str(cmd))
         if cmd.r != None:
-            self.handle_rudder_msg(cmd.r)
+            self.handle_rudder_cmd(cmd.r)
         if cmd.m != None:
-            self.handle_motor_msg(cmd.m)
+            self.handle_motor_cmd(cmd.m)
         if cmd.a != None:
-            self.handle_nav_radio_msg(cmd.a)
-        # try:
-        #     data = json.loads(message)
-        # except:
-        #     self.get_logger().warning(
-        #         "Could not parse json, incoming radio message: {}".format(message)
-        #     )
+            self.handle_nav_radio_cmd(cmd.a)
 
-        # if data:
-        #     if data.get(RUDDER_KEY) is not None:
-        #         self.handle_rudder_msg(data.get(RUDDER_KEY))
-
-        #     if data.get(MOTOR_KEY) is not None:
-        #         self.handle_motor_msg(data.get(MOTOR_KEY))
-
-        #     if data.get(NAV_KEY) is not None:
-        #         self.handle_nav_radio_msg(data.get(NAV_KEY))
-
-    def handle_nav_radio_msg(self, auto_mode_enabled):
+    def handle_nav_radio_cmd(self, auto_mode_enabled):
         nav_msg = Bool()
         nav_msg.data = bool(auto_mode_enabled)
         self.nav_publisher.publish(nav_msg)
 
-    def handle_nav_radio_msg2(self, msg):
-        if msg.get(AUTO_MODE_KEY) is not None:
-            nav_msg = Bool()
-            nav_msg.data = bool(msg.get(AUTO_MODE_KEY))
-            self.nav_publisher.publish(nav_msg)
+    def handle_rudder_cmd(self, rudder_msg_value):
+        rudder_value = float(rudder_msg_value)
+        topic_msg = Float32()
+        topic_msg.data = rudder_value
+        self.rudder_publisher.publish(topic_msg)
 
-    def handle_rudder_msg(self, rudder_msg_value):
-        rudder_value = None
-        try:
-            rudder_value = float(rudder_msg_value)
-        except:
-            self.get_logger().warning(
-                "Could not parse float, value {}".format(rudder_msg_value)
-            )
-
-        if rudder_value is not None:
-            topic_msg = Float32()
-            topic_msg.data = rudder_value
-            self.rudder_publisher.publish(topic_msg)
-
-    def handle_motor_msg(self, motor_msg_value):
-        motor_value = None
-        try:
-            motor_value = float(motor_msg_value)
-        except:
-            self.get_logger().warning(
-                "Could not parse float, value {}".format(motor_msg_value)
-            )
-
-        if motor_value is not None:
-            topic_msg = Float32()
-            topic_msg.data = motor_value
-            self.motor_publisher.publish(topic_msg)
-
-    def handle_nav_update(self, nav_msg):
-        next_target = None
-        if len(nav_msg.next_target) > 0 and nav_msg.auto_mode_enabled:
-            coordinate = nav_msg.next_target[0]
-            next_target = {
-                "coordinate": {"lat": coordinate.lat, "lon": coordinate.lon},
-                "distance": nav_msg.meters_to_target,
-                "tolerance": nav_msg.tolerance_in_meters,
-            }
-        data = {"nextTarget": next_target, "autoModeEnabled": nav_msg.auto_mode_enabled}
-        # self.update_state(data)
+    def handle_motor_cmd(self, motor_msg_value):
+        motor_value = float(motor_msg_value)
+        topic_msg = Float32()
+        topic_msg.data = motor_value
+        self.motor_publisher.publish(topic_msg)
 
 
 def main(args=None):

--- a/src/eel/eel/utils/nav.py
+++ b/src/eel/eel/utils/nav.py
@@ -83,6 +83,29 @@ def get_closest_turn_direction(current_heading, target_heading):
     return -1 if diff > 180 else 1
 
 
+def get_next_rudder_turn(current_heading, target_heading):
+    """
+    Given current heading and target heading, get instructions for how to turn rudder.
+
+    :param current_heading: In degrees
+    :param target_heading: In degrees
+    :return: -1.0 for left and 1.0 for right, and all values in between.
+    """
+    closest_angle_offset = abs(target_heading - current_heading) % 360
+    closest_angle_offset = (
+        360 - closest_angle_offset
+        if closest_angle_offset > 180
+        else closest_angle_offset
+    )
+
+    proportional_offset = closest_angle_offset / 180.0
+    rudder_adjustment = (
+        1 if abs(proportional_offset) > 0.1 else (proportional_offset * 3)
+    )
+    direction = get_closest_turn_direction(current_heading, target_heading)
+    return rudder_adjustment * direction
+
+
 if __name__ == "__main__":
     sample_pos_1 = {"latitude": 59.30766069495403, "longitude": 17.97525523434028}
     sample_pos_2 = {"latitude": 59.31200312176195, "longitude": 17.975909693329726}

--- a/src/eel/eel/utils/radio_helpers/client_side.py
+++ b/src/eel/eel/utils/radio_helpers/client_side.py
@@ -1,0 +1,81 @@
+import json
+from .utils import instance_to_str
+
+
+class ClientCoordinate:
+    def __init__(self) -> None:
+        self.lat = None
+        self.lon = None
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+
+class ClientNavState:
+    def __init__(self) -> None:
+        self.autoMode = None
+        self.distance = None
+        self.coordinate = None
+        self.tolerance = None
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+
+class ClientImuState:
+    def __init__(self) -> None:
+        self.heading = None
+        self.gyro = None
+        self.magnetometer = None
+        self.accelerometer = None
+        self.system = None
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+
+class ClientEelState:
+    def __init__(self) -> None:
+        self.positions = []
+        self.nav = ClientNavState()
+        self.imu = ClientImuState()
+
+    def update_eel_state(self, eel_state):
+        if eel_state.n:
+            self.update_nav(eel_state.n)
+        if eel_state.i:
+            self.update_imu(eel_state.i)
+        if eel_state.g:
+            self.update_gnss(eel_state.g)
+
+    def update_nav(self, eel_state_nav):
+        self.nav.autoMode = eel_state_nav.a
+        self.nav.coordinate = (
+            self.nav.coordinate if self.nav.coordinate else ClientCoordinate()
+        )
+        if eel_state_nav.c:
+            self.nav.coordinate.lat = eel_state_nav.c.lt
+            self.nav.coordinate.lon = eel_state_nav.c.ln
+        else:
+            self.nav.coordinate = None
+        self.nav.distance = eel_state_nav.d
+        self.nav.tolerance = eel_state_nav.t
+
+    def update_imu(self, eel_state_imu):
+        self.imu.heading = eel_state_imu.h
+        self.imu.gyro = eel_state_imu.g
+        self.imu.magnetometer = eel_state_imu.m
+        self.imu.accelerometer = eel_state_imu.a
+        self.imu.system = eel_state_imu.s
+
+    def update_gnss(self, eel_state_gnss):
+        coordinate = ClientCoordinate()
+        coordinate.lat = eel_state_gnss.c.lt
+        coordinate.lon = eel_state_gnss.c.ln
+        self.positions.append(coordinate)
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+    def to_dict(obj):
+        return json.loads(json.dumps(obj, default=lambda o: o.__dict__))

--- a/src/eel/eel/utils/radio_helpers/demo.py
+++ b/src/eel/eel/utils/radio_helpers/demo.py
@@ -1,0 +1,157 @@
+from .utils import to_json_filtered, instance_to_str
+from .eel_side import (
+    EelState,
+    from_json_to_state,
+    CommandMessage,
+    from_json_to_command,
+)
+from .client_side import ClientEelState
+
+# TODO: fix modules or whatever, so that this file can be run directly, with relative imports working
+
+
+class ExampleRosCoordinateMsg:
+    def __init__(self) -> None:
+        self.lat = 59.30940628051758
+        self.lon = 17.974245071411133
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+
+class ExampleRosImuMsg:
+    def __init__(self) -> None:
+        self.is_calibrated = True
+        self.sys = 3
+        self.gyro = 3
+        self.accel = 3
+        self.mag = 3
+        self.euler_heading = 180.0
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+
+class ExampleRosGnssMsg:
+    def __init__(self) -> None:
+        coordinate = ExampleRosCoordinateMsg()
+        self.lat = coordinate.lat
+        self.lon = coordinate.lon
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+
+class ExampleNavMsg:
+    def __init__(self) -> None:
+        self.meters_to_target = 150.0
+        self.tolerance_in_meters = 5.0
+        self.next_target = [ExampleRosCoordinateMsg()]
+        self.auto_mode_enabled = True
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+
+if __name__ == "__main__":
+    print()
+    print("=== CONVERT FROM RADIO MESSAGE TO COMMAND ===")
+    print()
+    incoming_cmd_obj = CommandMessage(m=1.0)
+    print(">> initialize incoming cmd obj")
+    print(incoming_cmd_obj)
+    print()
+
+    incoming_cmd_str = to_json_filtered(incoming_cmd_obj)
+    print(">> get this over radio")
+    print(incoming_cmd_str)
+    print()
+
+    incoming_cmd_converted = from_json_to_command(incoming_cmd_str)
+    print(">> convert to command")
+    print(incoming_cmd_converted)
+    print()
+
+    print(">> DONE!")
+    print()
+    print()
+    print("=== UPDATE STATE AND CONVERT TO RADIO MESSAGE ===")
+    print()
+
+    current_state = EelState()
+    print(">> empty state")
+    print(current_state)
+    print()
+
+    ros_imu = ExampleRosImuMsg()
+    ros_gnss = ExampleRosGnssMsg()
+    current_state.update_gnss(ros_gnss)
+    current_state.update_imu(ros_imu)
+    print(">> partially update state with")
+    print(ros_gnss)
+    print(ros_imu)
+    print()
+    print(">> updated state")
+    print(current_state)
+    print()
+
+    radio_msg_out = to_json_filtered(current_state)
+    print(">> send this")
+    print(radio_msg_out)
+    print()
+
+    ros_nav = ExampleNavMsg()
+    current_state.update_nav(ros_nav)
+    print(">> update state again with")
+    print(ros_nav)
+    print(">> updated state")
+    print(current_state)
+
+    print()
+    radio_msg_out_2 = to_json_filtered(current_state)
+    print(">> send this")
+    print(radio_msg_out_2)
+    print()
+
+    print(">> DONE!")
+    print()
+    print()
+    print("=== CONVERT FROM STATE RADIO MESSAGE TO CLIENT STATE ===")
+    print()
+
+    client_state = ClientEelState()
+    print(">> initial client state")
+    print(client_state)
+    print()
+
+    print(">> getting this")
+    print(radio_msg_out)
+    print()
+
+    incoming_state = from_json_to_state(radio_msg_out)
+    print(">> converted")
+    print(incoming_state)
+    print()
+
+    print(">> update client state")
+    client_state.update_eel_state(incoming_state)
+    print(client_state)
+    print()
+
+    print(">> and then getting this")
+    print(radio_msg_out_2)
+    print()
+
+    incoming_state_2 = from_json_to_state(radio_msg_out_2)
+    print(">> converted")
+    print(incoming_state_2)
+    print()
+
+    print(">> update client state again")
+    client_state.update_eel_state(incoming_state_2)
+    print(client_state)
+    print()
+
+    print(">> DONE!")
+    print()
+    print("========================================================")

--- a/src/eel/eel/utils/radio_helpers/eel_side.py
+++ b/src/eel/eel/utils/radio_helpers/eel_side.py
@@ -1,0 +1,107 @@
+import json
+from .utils import instance_to_str, to_json_filtered
+
+
+class ImuState:
+    def __init__(self, c=None, s=None, g=None, a=None, m=None, h=None) -> None:
+        self.c = c  # is calibrated
+        self.s = s  # system calibration value
+        self.g = g  # gyro calibration value
+        self.a = a  # accelerometer calibration value
+        self.m = m  # magnetometer calibration value
+        self.h = h  # heading
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+
+class Coordinate:
+    def __init__(self, lt=None, ln=None) -> None:
+        self.lt = lt  # latitude
+        self.ln = ln  # longitude
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+
+class GnssState:
+    def __init__(self, c=None) -> None:
+        self.c = None if not c else Coordinate(**c)
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+
+class NavState:
+    def __init__(self, c=None, d=None, t=None, a=None) -> None:
+        self.c = None if not c else Coordinate(**c)  # target coordinate
+        self.d = d  # distance to target
+        self.t = t  # target tolerance
+        self.a = a  # is auto mode enabled
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+
+class EelState:
+    def __init__(self, n=None, i=None, g=None) -> None:
+        self.n = None if not n else NavState(**n)
+        self.i = None if not i else ImuState(**i)
+        self.g = None if not g else GnssState(**g)
+
+    def update_imu(self, msg):
+        self.i = self.i if self.i else ImuState()
+        self.i.c = msg.is_calibrated
+        self.i.s = msg.sys
+        self.i.g = msg.gyro
+        self.i.a = msg.accel
+        self.i.m = msg.mag
+        self.i.h = msg.euler_heading
+
+    def update_gnss(self, msg):
+        self.g = self.g if self.g else GnssState()
+        self.g.c = self.g.c if self.g.c else Coordinate()
+        self.g.c.lt = msg.lat
+        self.g.c.ln = msg.lon
+
+    def update_nav(self, msg):
+        self.n = self.n if self.n else NavState()
+        if len(msg.next_target) > 0:
+            next_target = msg.next_target[0]
+            self.n.c = self.n.c if self.n.c else Coordinate()
+            self.n.c.lt = next_target.lat
+            self.n.c.ln = next_target.lon
+            self.n.d = msg.meters_to_target
+            self.n.t = msg.tolerance_in_meters
+        else:
+            self.n.c = None
+            self.n.d = None
+            self.n.t = None
+
+        self.n.a = msg.auto_mode_enabled
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+
+def from_json_to_state(data):
+    dict_converted = json.loads(data)
+    return EelState(**dict_converted)
+
+
+def from_state_to_json(state):
+    return to_json_filtered(state)
+
+
+class CommandMessage:
+    def __init__(self, m=None, r=None, a=None) -> None:
+        self.m = m
+        self.r = r
+        self.a = a
+
+    def __str__(self) -> str:
+        return instance_to_str(self)
+
+
+def from_json_to_command(data):
+    return json.loads(data, object_hook=lambda d: CommandMessage(**d))

--- a/src/eel/eel/utils/radio_helpers/utils.py
+++ b/src/eel/eel/utils/radio_helpers/utils.py
@@ -1,0 +1,18 @@
+import json
+
+
+def from_json(data):
+    return json.loads(data)
+
+
+def to_json(obj):
+    return json.dumps(obj, default=lambda o: o.__dict__)
+
+
+def to_json_filtered(obj):
+    only_set_keys = {k: v for k, v in obj.__dict__.items() if v is not None}
+    return to_json(only_set_keys)
+
+
+def instance_to_str(obj):
+    return "{}\n{}".format(obj.__repr__(), to_json(obj))

--- a/src/eel/eel/utils/topics.py
+++ b/src/eel/eel/utils/topics.py
@@ -17,3 +17,4 @@ RADIO_OUT = "radio/out"
 
 # Navigation
 NAVIGATION_STATUS = "nav/status"
+NAVIGATION_CMD = "nav/cmd"

--- a/src/eel_interfaces/msg/NavigationStatus.msg
+++ b/src/eel_interfaces/msg/NavigationStatus.msg
@@ -1,3 +1,4 @@
 float32 meters_to_target
 float32 tolerance_in_meters
 Coordinate[] next_target
+bool auto_mode_enabled


### PR DESCRIPTION
Sorry for enormous and messy PR!
(This one is also messy --> https://github.com/foxpoint-se/ground-control/pull/5)

- It's mostly messy because I tried to standardize how to send and receive messages over radio. Created a lot of classes to represent states on "eel side" and "client side", which are supposed to be synchronized when doing changes to the radio API. Since we don't have a way to share code between the two projects, one will therefore have to copy-paste the folder `radio_helpers` to the other project when updating the API. And then it **should** work :grimacing: But it probably won't, so this part can definately be improved. But it's a start at least.
- Wanted to do the above to be able to change the API to be cleaner and more compact. Previously we sent stuff like `{motor: 1.0}`, but now it's only `{m: 1.0}`. The internal eel state is also more compact. According to my calculations, we're saving almost 1000 bits, compared to previously. Example of state update below:
```
{
  "n": {
    "c": { "lt": 59.30938720703125, "ln": 17.975370407104492 },
    "d": 63.92890548706055,
    "t": 5.0,
    "a": false
  },
  "i": { "c": true, "s": 3, "g": 3, "a": 3, "m": 3, "h": 0.0 },
  "g": { "c": { "lt": 59.30940628051758, "ln": 17.974245071411133 } }
}
```
- Sending `auto` mode over radio, so we get that in frontend.
- Ability to toggle `auto` mode on or off.
- Update distance to target, even if in `manual` mode. Makes the frontend more informative, so you know if you're driving away or towards the target.