### PR TITLE
Miscellaneous stuff after trimming session

### DIFF
--- a/src/eel/eel/pressure/pressure_sensor.py
+++ b/src/eel/eel/pressure/pressure_sensor.py
@@ -3,8 +3,11 @@ import ms5837
 from rclpy.node import Node
 
 # meters
-CALIBRATION_DEPTH_1 = 0
-CALIBRATION_DEPTH_2 = 0.08
+CALIBRATION_DEPTH_1 = 0.03
+CALIBRATION_DEPTH_2 = 0.40
+
+CALIBRATION_VALUE_1 = 201.08855674940125
+CALIBRATION_VALUE_2 = 208.52912813488265
 
 
 class PressureSensor:
@@ -18,10 +21,10 @@ class PressureSensor:
 
         self.logger = parent_node.get_logger()
         self.sensor.setFluidDensity(ms5837.DENSITY_FRESHWATER)
-        self.depth_1_value = None
-        self.depth_2_value = None
+        self.depth_1_value = CALIBRATION_VALUE_1
+        self.depth_2_value = CALIBRATION_VALUE_2
 
-        self._calibrate()
+        # self._calibrate()
 
     def _get_depth_reading(self):
         self.sensor.read()
@@ -46,7 +49,7 @@ class PressureSensor:
         self.logger.info(
             "Second step: Hold pressure sensor at {} m".format(CALIBRATION_DEPTH_2)
         )
-        time.sleep(5)
+        time.sleep(10)
         self.depth_2_value = self._get_depth_reading()
         self.logger.info("Calibration done!")
         self.logger.info(

--- a/src/eel/eel/tank/distance_sensor.py
+++ b/src/eel/eel/tank/distance_sensor.py
@@ -27,7 +27,7 @@ def wait_for_address_change(xshut_pin):
 # 50000: fast but less accurate
 class DistanceSensor:
     def __init__(
-        self, address, timing_budget=500000, xshut_pin=0, parent_node: Node = None
+        self, address, timing_budget=1000000, xshut_pin=0, parent_node: Node = None
     ):
         self.address = address
         self.xshut_pin = xshut_pin

--- a/src/eel/eel/tank/pump_motor_control.py
+++ b/src/eel/eel/tank/pump_motor_control.py
@@ -31,7 +31,8 @@ class PumpMotorControl(PumpStateControl):
 
     def _start_motor(self):
         # GPIO.output(self.motor_pin, RUN_GPIO_LEVEL)
-        self.pwm_output.start(80)
+        # self.pwm_output.start(80)
+        self.pwm_output.start(60)
 
     def _stop_motor(self):
         # GPIO.output(self.motor_pin, STOP_GPIO_LEVEL)

--- a/src/eel_bringup/launch/tanks.launch.py
+++ b/src/eel_bringup/launch/tanks.launch.py
@@ -57,7 +57,15 @@ def generate_launch_description():
         ],
     )
 
+    pressure_node = Node(
+        package="eel",
+        executable="pressure",
+        name="pressure_node",
+        parameters=[{SIMULATE_PARAM: False}],
+    )
+
     ld.add_action(front_tank_node)
     ld.add_action(rear_tank_node)
+    # ld.add_action(pressure_node)
 
     return ld


### PR DESCRIPTION
- Use hardcoded values in `pressure_sensor`, instead of running calibration on startup.
- Double the `timing_budget`, since it makes the measurements more precise.
- Run pump motors at `60` instead of `80`, since it makes it easier to approach target level.
- Publish measured pump level in millimeters to a debug topic, to be able to plot it in `rqt`.