### PR TITLE
Feature: Extend navigation node to support coordinate updates

### DIFF
--- a/src/eel/eel/utils/topics.py
+++ b/src/eel/eel/utils/topics.py
@@ -15,6 +15,7 @@ IMU_STATUS = "imu/status"
 # Navigation
 NAVIGATION_STATUS = "nav/status"
 NAVIGATION_CMD = "nav/cmd"
+NAVIGATION_COORDINATE_UPDATE = "nav/coordinate_update"
 
 # Tanks
 FRONT_TANK_CMD = "tank_front/cmd"

--- a/src/eel/eel/utils/topics.py
+++ b/src/eel/eel/utils/topics.py
@@ -15,7 +15,8 @@ IMU_STATUS = "imu/status"
 # Navigation
 NAVIGATION_STATUS = "nav/status"
 NAVIGATION_CMD = "nav/cmd"
-NAVIGATION_COORDINATE_UPDATE = "nav/coordinate_update"
+NAVIGATION_UPDATE_COORDINATE = "nav/update_coordinate"
+NAVIGATION_SET_TARGET = "nav/set_target"
 
 # Tanks
 FRONT_TANK_CMD = "tank_front/cmd"

--- a/src/eel_interfaces/msg/Coordinate.msg
+++ b/src/eel_interfaces/msg/Coordinate.msg
@@ -1,2 +1,3 @@
 float32 lat
 float32 lon
+int8 index

--- a/src/eel_interfaces/msg/Coordinate.msg
+++ b/src/eel_interfaces/msg/Coordinate.msg
@@ -1,3 +1,2 @@
 float32 lat
 float32 lon
-int8 index


### PR DESCRIPTION
The idea is that the navigation node should support updates of coordinates instead of us hard
coding them. Also there should be a way to add a new target in case something was to happen i.e avoiding or getting a better turn angle.

Two new topics:
nav/update_coordinate - adds coordinate to the end of the coordinate list
nav/set_target - sets new target to the coordinate and updates the coordinate list so that new target replaces current index and then the rest is added afterwards

Sample messages can be sent with:
ros2 topic pub /nav/update_coordinate eel_interfaces/msg/Coordinate '{"lat":59.31018386602032,"lon":17.97421216964722}' --once
ros2 topic pub /nav/set_target eel_interfaces/msg/Coordinate '{"lat":59.31076430556275,"lon":17.976057529449466}' --once