### PR TITLE
Refactor: Modem node to use services

### DIFF
--- a/src/eel/eel/modem/modem_node.py
+++ b/src/eel/eel/modem/modem_node.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 import rclpy
 from rclpy.node import Node
-from eel_interfaces.msg import ModemStatus
+from eel_interfaces.srv import ModemStatus
 from ..utils.constants import SIMULATE_PARAM
-from ..utils.topics import MODEM_STATUS
 
 
 class ModemNode(Node):  # MODIFY NAME
@@ -11,10 +10,8 @@ class ModemNode(Node):  # MODIFY NAME
         super().__init__("modem_node")
         self.declare_parameter(SIMULATE_PARAM, False)
         self.should_simulate = self.get_parameter(SIMULATE_PARAM).value
-        self.status_publisher = self.create_publisher(ModemStatus, MODEM_STATUS, 10)
-
-        # hertz (publications per second)
-        self.update_frequency = 0.10
+        self.srv = self.create_service(ModemStatus, "modem_status", self.get_modem_status)
+        self.logger = self.get_logger()
 
         if not self.should_simulate:
             from .modem_sensor import ModemSensor
@@ -33,23 +30,18 @@ class ModemNode(Node):  # MODIFY NAME
                 "Could not start modem node. Not getting registration status and/or signal strength."
             )
 
-        self.updater = self.create_timer(
-            1.0 / self.update_frequency, self.publish_modem
-        )
-
-        self.get_logger().info(
+        self.logger.info(
             f"{'Simulate ' if self.should_simulate else ''}Modem node started"
         )
 
-    def publish_modem(self):
-        reg_status = self.sensor.get_registration_status()
-        signal_strength = self.sensor.get_received_signal_strength_indicator()
+    def get_modem_status(self, request, response):
+        response.reg_status = self.sensor.get_registration_status()
+        response.signal_strength = self.sensor.get_received_signal_strength_indicator()
 
-        msg = ModemStatus()
-        msg.reg_status = reg_status
-        msg.signal_strength = signal_strength
+        self.logger.info(f"Built response for incomin request for modem status.")
+        self.logger.info(f"Reg status: {response.reg_status}, Signal strength {response.signal_strength}")                  
 
-        self.status_publisher.publish(msg)
+        return response
 
 
 def main(args=None):

--- a/src/eel/eel/utils/topics.py
+++ b/src/eel/eel/utils/topics.py
@@ -31,6 +31,3 @@ DEPTH_CONTROL_CMD = "depth_control/cmd"
 
 # Battery
 BATTERY_STATUS = "battery/status"
-
-# Modem
-MODEM_STATUS = "modem/status"

--- a/src/eel_interfaces/CMakeLists.txt
+++ b/src/eel_interfaces/CMakeLists.txt
@@ -29,7 +29,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/BatteryStatus.msg"
   "msg/PidDepthCmd.msg"
   "msg/PidPitchCmd.msg"
-  "msg/ModemStatus.msg"
+  "srv/ModemStatus.srv"
 )
 
 ament_package()

--- a/src/eel_interfaces/msg/ModemStatus.msg
+++ b/src/eel_interfaces/msg/ModemStatus.msg
@@ -1,2 +1,0 @@
-int8 reg_status
-int8 signal_strength

--- a/src/eel_interfaces/srv/ModemStatus.srv
+++ b/src/eel_interfaces/srv/ModemStatus.srv
@@ -1,0 +1,3 @@
+---
+int8 reg_status
+int8 signal_strength


### PR DESCRIPTION
Have the modem node use services to communicate.

How to test:
#1 Start modem node: ros2 run eel modem --ros-args -p simulate:=true
#2 Send service request: ros2 service call /modem_status eel_interfaces/srv/ModemStatus