### PR TITLE
Extend dive action client with services

### DIFF
--- a/src/eel/eel/dive/dive_action_client.py
+++ b/src/eel/eel/dive/dive_action_client.py
@@ -1,56 +1,127 @@
+import time
+
 import rclpy
+from action_msgs.msg import GoalStatus
 from rclpy.action import ActionClient
 from rclpy.node import Node
 
 from eel_interfaces.action import Dive
+from eel_interfaces.srv import StartDive, CancelDive
+from eel_interfaces.msg import DiveStatus
+
+from ..utils.topics import DIVE_STATUS
+
+
+MAX_SRV_RESPONSE_TIME = 3
 
 
 class DiveActionClient(Node):
     def __init__(self):
-        super().__init__('dive_action_client')
-        self._action_client = ActionClient(self, Dive, "dive")
-
+        super().__init__("dive_action_client")
         self.logger = self.get_logger()
+        self._action_client = ActionClient(self, Dive, "dive")
+        self._goal_handle = None
+        self.dive_feedback_counter = 0
 
-    def send_goal(self, wanted_depth):
+        self.start_dive_srv = self.create_service(StartDive, "start_dive", self.start_dive)
+        self.cancel_dive_srv = self.create_service(CancelDive, "cancel_dive", self.cancel_dive)
+
+        self.status_publisher = self.create_publisher(DiveStatus, DIVE_STATUS, 10)
+
+        self.logger.info("Dive action client node started.")
+
+    def start_dive(self, request, response):
+        request_recieved = time.time()
+        wanted_depth = request.wanted_depth
+        dive_time = request.dive_time
+
+        # Check if there already is a goal in progress
+        if self._goal_handle is not None:
+            status = self._goal_handle.status()
+            self.logger.info(f"Currently goal running with status {status}, unable to set new goal.")
+            response.dive_accepted = False
+            
+            return response
+
+        self.send_goal(wanted_depth, dive_time)
+        response.dive_accepted = True
+
+        return response
+
+    def cancel_dive(self, request, response):
+        if self._goal_handle is None:
+            self.logger.info("No active goal handle, cannot issue cancel command.")
+            response.dive_canceled = False
+
+            return response
+
+        self.cancel_goal()
+        response.dive_canceled = True
+
+        return response
+
+    def send_goal(self, wanted_depth, dive_time):
         goal_msg = Dive.Goal()
         goal_msg.wanted_depth = wanted_depth
+        goal_msg.dive_time = dive_time
 
         self._action_client.wait_for_server()
+
+        self.logger.info(f"Initiating dive to depth {wanted_depth} for {dive_time}s.")
 
         self._send_goal_future = self._action_client.send_goal_async(
             goal_msg, feedback_callback=self.feedback_callback)
 
         self._send_goal_future.add_done_callback(self.goal_response_callback)
     
+    def cancel_goal(self):
+        self._goal_handle.cancel_goal_async()
+    
     def goal_response_callback(self, future):
         goal_handle = future.result()
-        
+
         if not goal_handle.accepted:
-            self.logger.info("Goal was rejected.")
+            self.logger.info("Goal was rejected by server.")
             return
 
-        self.logger.info("Goal accepted.")
+        self.logger.info("Goal was accepted!!!")
+        self._goal_handle = goal_handle
 
         self._get_result_future = goal_handle.get_result_async()
         self._get_result_future.add_done_callback(self.get_result_callback)
     
     def get_result_callback(self, future):
-        result = future.result().result
-        self.logger.info(f"Result, final depth: {result.final_depth}m")
-        rclpy.shutdown()
+        status = future.result().status
+
+        if status == GoalStatus.STATUS_SUCCEEDED:
+            result = future.result().result
+            self.logger.info(f"Goal finished successfully, action time: {result.action_time}")
+
+        elif status == GoalStatus.STATUS_CANCELED:
+            self.logger.info("Goal was cancelled")
+
+        self._goal_handle = None
+        self.dive_feedback_counter = 0
 
     def feedback_callback(self, feedback_msg):
+        self.dive_feedback_counter += 1
+
+        if self.dive_feedback_counter % 5 == 0:
+            msg = DiveStatus()
+            msg.current_depth = feedback_msg.feedback.current_depth
+            msg.time_left = feedback_msg.feedback.time_left
+            msg.depth_reached_after =  feedback_msg.feedback.depth_reached_after
+
+            self.status_publisher.publish(msg)
+
         feedback = feedback_msg.feedback
         self.logger.info(f"Recieved feedback, now at: {round(feedback.current_depth, 5)}m")
 
 def main(args=None):
     rclpy.init(args=args)
-    
     action_client = DiveActionClient()
-    action_client.send_goal(2.0)
-    
     rclpy.spin(action_client)
+    rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/modem/modem_sensor.py
+++ b/src/eel/eel/modem/modem_sensor.py
@@ -7,11 +7,7 @@ import time
 from .modem_source import ModemSource
 
 
-AT_COMMAND_TIMEOUT_MS = 5000
-
-
-def get_time_with_ms():
-    return int(time.time() * 1000)
+AT_COMMAND_TIMEOUT_MS = 500
 
 
 class ModemSensor(ModemSource):
@@ -21,11 +17,10 @@ class ModemSensor(ModemSource):
         self.serial_connection.stopbits = serial.STOPBITS_ONE
         self.serial_connection.bytesize = serial.EIGHTBITS
 
-    def get_response(self, timeout_ms=AT_COMMAND_TIMEOUT_MS):
+    def get_response(self):
         """Reads a response from the modem, reading is done over serial and response can 
         take up 100 milliseconds to be read.
         
-        :param timeout_ms: Time out in milliseconds for the serial read function
         :return: Response read from the modem in string format UTF-8 decoded
         """
         time.sleep(0.1)

--- a/src/eel/eel/utils/topics.py
+++ b/src/eel/eel/utils/topics.py
@@ -33,3 +33,6 @@ DEPTH_CONTROL_CMD = "depth_control/cmd"
 
 # Battery
 BATTERY_STATUS = "battery/status"
+
+# Diving
+DIVE_STATUS = "dive/status"

--- a/src/eel_interfaces/CMakeLists.txt
+++ b/src/eel_interfaces/CMakeLists.txt
@@ -30,9 +30,12 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/PidDepthCmd.msg"
   "msg/PidPitchCmd.msg"
   "msg/NavigationMission.msg"
+  "msg/DiveStatus.msg"
   "action/Dive.action"
   "action/Navigate.action"
   "srv/ModemStatus.srv"
+  "srv/CancelDive.srv"
+  "srv/StartDive.srv"
 )
 
 ament_package()

--- a/src/eel_interfaces/action/Dive.action
+++ b/src/eel_interfaces/action/Dive.action
@@ -3,9 +3,8 @@ float32 dive_time
 ---
 float32 final_depth
 float32 action_time
+float32 depth_reached_after
 ---
 float32 current_depth
 float32 time_left
 float32 depth_reached_after
-float32 pid_rudder_output
-float32 pid_angle_output

--- a/src/eel_interfaces/msg/DiveStatus.msg
+++ b/src/eel_interfaces/msg/DiveStatus.msg
@@ -1,0 +1,3 @@
+float32 current_depth
+float32 time_left
+float32 depth_reached_after

--- a/src/eel_interfaces/srv/CancelDive.srv
+++ b/src/eel_interfaces/srv/CancelDive.srv
@@ -1,0 +1,2 @@
+---
+bool dive_canceled

--- a/src/eel_interfaces/srv/StartDive.srv
+++ b/src/eel_interfaces/srv/StartDive.srv
@@ -1,0 +1,4 @@
+float32 wanted_depth
+float32 dive_time
+---
+bool dive_accepted


### PR DESCRIPTION
Extend the dive action client to use services to initiate and cancel dives. 

Can be tested with the following commands:
1. Run all 'drive' simulated nodes: `make start-sim-drive`
2. Run dive action server: `ros2 run eel dive`
3. Run dive action client: `ros2 run eel dive_client`
4. Simulating depth needs to motor to be running, send start motor cmd: 
    `ros2 topic pub /motor/cmd std_msgs/Float32 '{data: 1.0}'`
5. Send service call to start dive: `ros2 service call /start_dive eel_interfaces/srv/StartDive "{wanted_depth: 1.0, dive_time: 45.0}"`

Can be used with the ground control app to see the effect.