### PR TITLE
fix(nav): set target depth to zero after every finished assignment

### DIFF
--- a/src/eel/eel/navigation/navigation_action_server.py
+++ b/src/eel/eel/navigation/navigation_action_server.py
@@ -223,6 +223,7 @@ class NavigationActionServer(Node):
         self.logger.info("Finished goal.")
         self.publish_motor_cmd(0.0)
         self.publish_rudder_cmd(0.0)
+        self.publish_depth_cmd(0.0)
 
         result = Navigate.Result()
         result.success = True


### PR DESCRIPTION
Just in case. Seemed to be working anyway, but if we want to manually control it during any interruption, we want it to travel at the surface.