### PR TITLE
chore: make docker compose save logs, so that we can check them later

### DIFF
--- a/docker/rotholmen-alen-template.yml
+++ b/docker/rotholmen-alen-template.yml
@@ -1,4 +1,11 @@
 version: "3.9"
+
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "5m"
+    max-file: "3"
+
 services:
   imu:
     image: foxpoint/eel:foxy
@@ -10,6 +17,7 @@ services:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
     volumes:
       - ./cyclonedds.xml:/eel/cyclonedds.xml:r
+    logging: *default-logging
 
   motor:
     image: foxpoint/eel:foxy
@@ -20,6 +28,7 @@ services:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
     volumes:
       - ./cyclonedds.xml:/eel/cyclonedds.xml:r
+    logging: *default-logging
 
   rudder:
     image: foxpoint/eel:foxy
@@ -30,6 +39,7 @@ services:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
     volumes:
       - ./cyclonedds.xml:/eel/cyclonedds.xml:r
+    logging: *default-logging
 
   battery:
     image: foxpoint/eel:foxy
@@ -41,6 +51,7 @@ services:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
     volumes:
       - ./cyclonedds.xml:/eel/cyclonedds.xml:r
+    logging: *default-logging
 
   pressure:
     image: foxpoint/eel:foxy
@@ -52,6 +63,7 @@ services:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
     volumes:
       - ./cyclonedds.xml:/eel/cyclonedds.xml:r
+    logging: *default-logging
 
   gnss:
     image: foxpoint/eel:foxy
@@ -63,6 +75,7 @@ services:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
     volumes:
       - ./cyclonedds.xml:/eel/cyclonedds.xml:r
+    logging: *default-logging
 
   depth_control:
     image: foxpoint/eel:foxy
@@ -72,6 +85,7 @@ services:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
     volumes:
       - ./cyclonedds.xml:/eel/cyclonedds.xml:r
+    logging: *default-logging
 
   modem:
     image: foxpoint/eel:foxy
@@ -84,6 +98,7 @@ services:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
     volumes:
       - ./cyclonedds.xml:/eel/cyclonedds.xml:r
+    logging: *default-logging
 
   mqtt_bridge:
     image: foxpoint/eel:foxy
@@ -94,6 +109,7 @@ services:
     network_mode: ${NETWORK_MODE:-host}
     environment:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
+    logging: *default-logging
 
   navigation_action_server:
     image: foxpoint/eel:foxy
@@ -103,6 +119,7 @@ services:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
     volumes:
       - ./cyclonedds.xml:/eel/cyclonedds.xml:r
+    logging: *default-logging
 
   navigation_action_client:
     image: foxpoint/eel:foxy
@@ -112,6 +129,7 @@ services:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
     volumes:
       - ./cyclonedds.xml:/eel/cyclonedds.xml:r
+    logging: *default-logging
 
   leakage:
     image: foxpoint/eel:foxy
@@ -122,6 +140,7 @@ services:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
     volumes:
       - ./cyclonedds.xml:/eel/cyclonedds.xml:r
+    logging: *default-logging
 
   localization:
     image: foxpoint/eel:foxy
@@ -131,6 +150,7 @@ services:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
     volumes:
       - ./cyclonedds.xml:/eel/cyclonedds.xml:r
+    logging: *default-logging
 
   data_logger:
     image: foxpoint/eel:foxy
@@ -140,6 +160,7 @@ services:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
     volumes:
       - ./cyclonedds.xml:/eel/cyclonedds.xml:r
+    logging: *default-logging
 
   ros_bag:
     image: foxpoint/eel:foxy
@@ -150,3 +171,4 @@ services:
     network_mode: ${NETWORK_MODE:-host}
     environment:
       CYCLONEDDS_URI: file:///eel/cyclonedds.xml
+    logging: *default-logging


### PR DESCRIPTION
Please note that you'll need to run `docker compose stop` rather than `docker compose down`. Then `down` command removes the containers, which means that the container's logs will go out the window too. With the `stop` command we'll be able to find all the logs easily, for example with `docker compose logs my_service` or just `docker compose logs` to get everything.