### PR TITLE
Add cross track error sim

### DIFF
--- a/src/eel/eel/battery/battery_sensor.py
+++ b/src/eel/eel/battery/battery_sensor.py
@@ -9,22 +9,34 @@ class BatterySensor:
         self.ina = INA226(busnum=1, max_expected_amps=16, log_level=logging.INFO)
         self.ina.configure()
 
+    # TODO: not percent. change name to get_voltage_ratio
     def get_voltage_percent(self):
         voltage = self.ina.voltage()
         percent = calculate_voltage_percent(voltage)
         return float(percent / 100)
 
+    # NOTE: unit is V
+    # TODO: include unit in name
     def get_voltage(self):
         return self.ina.voltage()
 
+    # NOTE: unit is mA
+    # TODO: include unit in name
     def get_current(self):
         return self.ina.current()
 
+    # NOTE: unit is mW
+    # TODO: divide by 1000 so that unit is W
+    # TODO: include unit in name
     def get_power(self):
         return self.ina.power()
 
+    # NOTE: unit is V
+    # TODO: include unit in name
     def get_supply_voltage(self):
         return self.ina.supply_voltage()
 
+    # NOTE: unit is V
+    # TODO: include unit in name
     def get_shunt_voltage(self):
         return self.ina.shunt_voltage()

--- a/src/eel/eel/imu/imu_node.py
+++ b/src/eel/eel/imu/imu_node.py
@@ -54,6 +54,8 @@ class ImuNode(Node):
         self.get_imu_offsets = self.sensor.get_calibration_offsets
 
         self.updater = self.create_timer(1.0 / self.update_frequency, self.publish_imu)
+
+        # TODO: clean up the updating stuff. we'll just go with hard-coded constructor for now.
         # self.imu_offsets_updater = self.create_timer(1.0 / self.publish_offsets_freq, self.publish_imu_offsets)
         # self.imu_offsets_writer = self.create_timer(1.0 / self.update_calibration_offsets_freq, self.write_calibration_offsets)
 

--- a/src/eel/eel/imu/imu_node.py
+++ b/src/eel/eel/imu/imu_node.py
@@ -47,15 +47,15 @@ class ImuNode(Node):
 
         else:
             self.sensor = ImuSimulator(self)
-            
+
         self.get_euler = self.sensor.get_euler
         self.get_calibration_status = self.sensor.get_calibration_status
         self.get_is_calibrated = self.sensor.get_is_calibrated
         self.get_imu_offsets = self.sensor.get_calibration_offsets
 
         self.updater = self.create_timer(1.0 / self.update_frequency, self.publish_imu)
-        self.imu_offsets_updater = self.create_timer(1.0 / self.publish_offsets_freq, self.publish_imu_offsets)
-        self.imu_offsets_writer = self.create_timer(1.0 / self.update_calibration_offsets_freq, self.write_calibration_offsets)
+        # self.imu_offsets_updater = self.create_timer(1.0 / self.publish_offsets_freq, self.publish_imu_offsets)
+        # self.imu_offsets_writer = self.create_timer(1.0 / self.update_calibration_offsets_freq, self.write_calibration_offsets)
 
         self.get_logger().info(
             "{}IMU node started.".format("SIMULATE " if self.should_simulate else "")
@@ -97,7 +97,7 @@ class ImuNode(Node):
 
     def publish_imu_offsets(self):
         imu_offsets_map = self.get_imu_offsets()
-        
+
         msg = ImuOffsets()
         msg.mag = list(imu_offsets_map["mag"])
         msg.gyr = list(imu_offsets_map["gyr"])
@@ -108,7 +108,6 @@ class ImuNode(Node):
     def write_calibration_offsets(self):
         if SENSOR_CALIBRATION_OFFSETS:
             self.sensor.set_offset_values(SENSOR_CALIBRATION_OFFSETS)
-
 
 
 def main(args=None):

--- a/src/eel/eel/imu/imu_sensor.py
+++ b/src/eel/eel/imu/imu_sensor.py
@@ -57,6 +57,7 @@ CALIBRATION_2 = {
 
 my_calibration = CALIBRATION_1
 
+
 class ImuSensor:
     def __init__(self):
         import adafruit_bno055
@@ -64,7 +65,10 @@ class ImuSensor:
 
         i2c = board.I2C()
         self.sensor = adafruit_bno055.BNO055_I2C(i2c)
-        self.set_offset_values(CALIBRATION_1)
+        # self.set_offset_values(CALIBRATION_1)
+        self.sensor.offsets_magnetometer = (197, -106, 227)
+        self.sensor.offsets_gyroscope = (-1, -5, 1)
+        self.sensor.offsets_accelerometer = (-1, -32, -30)
 
     def get_is_calibrated(self):
         return self.sensor.calibrated or False
@@ -80,12 +84,12 @@ class ImuSensor:
         roll = get_corrected_roll(float(roll or 0))
         pitch = get_corrected_pitch(-float(pitch or 0))
         return heading, roll, pitch
-    
+
     def get_calibration_offsets(self) -> CalibrationOffsets:
         offset_mapping = {
             "mag": self.sensor.offsets_magnetometer,
             "gyr": self.sensor.offsets_gyroscope,
-            "acc": self.sensor.offsets_accelerometer
+            "acc": self.sensor.offsets_accelerometer,
         }
 
         return offset_mapping

--- a/src/eel/eel/localization/localizer.py
+++ b/src/eel/eel/localization/localizer.py
@@ -19,12 +19,20 @@ class Localizer:
         self._current_heading: float = 0.0
         self._total_meters_traveled: float = 0.0
         self._current_depth: float = 0.0
+        self._drift_speed: float = 0.0
+        self._drift_bearing: float = 0.0
 
     def update_speed_mps(self, new_speed_mps: float) -> None:
         self._current_speed_mps = new_speed_mps
 
     def update_heading(self, new_heading: float) -> None:
         self._current_heading = new_heading
+
+    def update_drift_speed_mps(self, new_drift_speed) -> None:
+        self._drift_speed = new_drift_speed
+
+    def update_drift_bearing(self, new_drift_bearing) -> None:
+        self._drift_bearing = new_drift_bearing
 
     def update_known_position(self, new_position: LatLon) -> None:
         if self._current_depth >= 0.3:
@@ -45,14 +53,21 @@ class Localizer:
 
             time_delta = current_time_sec - self._last_recorded_at
 
+            drift_meters = self._drift_speed * time_delta
+
             meters_traveled = self._current_speed_mps * time_delta
             self._total_meters_traveled += meters_traveled
             new_position = distance.distance(meters=meters_traveled).destination(
                 (self._current_position["lat"], self._current_position["lon"]),
                 bearing=self._current_heading,
             )
+
+            final_position = distance.distance(meters=drift_meters).destination(
+                (new_position.latitude, new_position.longitude), bearing=self._drift_bearing
+            )
+
             self._current_position = LatLon(
-                lat=new_position.latitude, lon=new_position.longitude
+                lat=final_position.latitude, lon=final_position.longitude
             )
 
         self._last_recorded_at = current_time_sec

--- a/src/eel/eel/mqtt_bridge/node.py
+++ b/src/eel/eel/mqtt_bridge/node.py
@@ -157,9 +157,9 @@ def transform_imu_msg(msg: ImuStatus) -> ImuStatusMqtt:
 
 def transform_imu_offsets_msg(msg: ImuOffsets) -> ImuOffsetsMqtt:
     return {
-        "mag": msg.mag,
-        "gyr": msg.gyr,
-        "acc": msg.acc
+        "mag": [v for v in msg.mag],
+        "acc": [v for v in msg.acc],
+        "gyr": [v for v in msg.gyr],
     }
 
 

--- a/src/eel/eel/navigation/assignments.py
+++ b/src/eel/eel/navigation/assignments.py
@@ -139,7 +139,7 @@ class WaypointAndDepth(Assignment):
 
         bearing_of_path = self._initial_bearing_to_target
         ect = cross_track_error
-        kct = -20.0  # NOTE: -20 works pretty good
+        kct = -7.0  # NOTE: -20 works pretty good
         # kct = -5.0
         corrective_turn_angle = ect * kct
 

--- a/src/eel/eel/navigation/assignments.py
+++ b/src/eel/eel/navigation/assignments.py
@@ -80,27 +80,64 @@ class WaypointAndDepth(Assignment):
 
         bearing_to_target = get_relative_bearing(current_position, self.target_pos)
 
-        # Desired = Bearing of path - min(corrective turn angel, 90)
-        offset_angle = abs(bearing_to_target - self._initial_bearing_to_target) % 360
-        offset_angle = (
-            360 - offset_angle
-            if offset_angle > 180
-            else offset_angle
-        )
+        # offset_angle = abs(bearing_to_target - self._initial_bearing_to_target) % 360
+        # offset_angle = 360 - offset_angle if offset_angle > 180 else offset_angle
 
-        closest_turn = get_closest_turn_direction(self._initial_bearing_to_target, bearing_to_target)
-        offset = closest_turn * offset_angle
+        # closest_turn = get_closest_turn_direction(
+        #     self._initial_bearing_to_target, bearing_to_target
+        # )
+        # offset = closest_turn * offset_angle
 
-        print(f"Calculated offset is: {offset}")
+        offset = bearing_to_target - self._initial_bearing_to_target
+
+        # print(f"Calculated offset is: {offset}")
 
         cross_track_error = sin(radians(offset)) * distance_to_target
-        next_rudder_turn = cap_value(cross_track_error * 0.05, -1.0, 1.0)
-        
-        print(f"Cross track error: {cross_track_error}m")
-        print(f"Next rudder turn: {next_rudder_turn}")
+        # next_rudder_turn = cap_value(cross_track_error * 0.05, -1.0, 1.0)
 
-        #next_rudder_turn = get_next_rudder_turn(current_heading, bearing_to_target)
+        # print(f"Cross track error: {cross_track_error}m")
+        # print(f"Next rudder turn: {next_rudder_turn}")
+
+        # next_rudder_turn = get_next_rudder_turn(current_heading, bearing_to_target)
+        # self.on_set_rudder(next_rudder_turn)
+
+        # desired heading = bearing of path - min(corrective turn angle, 90)
+        # where
+        # corrective turn angle = kct * ect
+        # where
+        # kct = ???? kp-värde??
+        # ect = avstånd till optimal path
+
+        bearing_of_path = self._initial_bearing_to_target
+        ect = cross_track_error
+        kct = -5.0  # TODO: change this??
+        corrective_turn_angle = ect * kct
+
+        # NOTE: when capping here, we might get a value like -250, since it's smaller than 90
+        # this results in it turning full circle when we have a large error
+        # instead we're capping between -90 and 90. this way we're avoiding turning the wrong way
+
+        # NOTE: we have not solved what to do if we have passed the point.
+        # the eel will return to desired path, but since it has passed the waypoint,
+        # it will keep on going away from it. just following desired angle.
+        # we need to fix that somehow. like: if it has passed it (if some angle is greater than some
+        # value or something?) then we should just head for the waypoint instead.
+        # i dunno.
+
+        # desired_heading = (bearing_of_path - min(corrective_turn_angle, 90)) % 360
+        desired_heading = (
+            bearing_of_path - cap_value(corrective_turn_angle, -90, 90)
+        ) % 360
+        # desired_heading = bearing_of_path - min(corrective_turn_angle, 90)
+
+        print("bearing_of_path", bearing_of_path)
+        print("corrective_turn_angle", corrective_turn_angle)
+        print("desired_heading", desired_heading)
+
+        next_rudder_turn = get_next_rudder_turn(current_heading, desired_heading)
+
         self.on_set_rudder(next_rudder_turn)
+
         return {"distance_to_target": distance_to_target}
 
     def start(self) -> None:
@@ -158,7 +195,7 @@ class SurfaceAssignment(Assignment):
         bearing_to_target = get_relative_bearing(current_position, self.target_pos)
 
         next_rudder_turn = get_next_rudder_turn(current_heading, bearing_to_target)
-        
+
         print(f"Bearing to target: {bearing_to_target}")
         print(f"Distance to target: {distance_to_target}")
         print(f"Inital bearing to target: {self._initial_bearing_to_target}")
@@ -167,8 +204,8 @@ class SurfaceAssignment(Assignment):
 
         print(f"Angle offset: {offset_angle}")
 
-        # drift_in_meters = 
-        
+        # drift_in_meters =
+
         self.on_set_rudder(next_rudder_turn)
         self.last_update_at = time()
         return {"distance_to_target": distance_to_target}

--- a/src/eel/eel/navigation/assignments.py
+++ b/src/eel/eel/navigation/assignments.py
@@ -70,6 +70,8 @@ def has_passed_waypoint(prev_wp, cur_wp, vehicle_pos):
     return t > 1
 
 
+# TODO: the start_pos should optimally be the start of the route, rather than current position.
+# If there is one, that is. for the first segment, the start_pos has to be current position.
 class WaypointAndDepth(Assignment):
     def __init__(
         self,
@@ -90,6 +92,7 @@ class WaypointAndDepth(Assignment):
         self._prev_wp = (start_pos["lat"], start_pos["lon"])
         self._curr_wp = (target_pos["lat"], target_pos["lon"])
 
+    # TODO: the logic with compensating for cross track error needs to be done for diving assignments as well.
     def step(
         self,
         current_position: LatLon,
@@ -109,6 +112,7 @@ class WaypointAndDepth(Assignment):
 
         bearing_to_target = get_relative_bearing(current_position, self.target_pos)
 
+        # TODO: clean up commented code and stuff here
         # offset_angle = abs(bearing_to_target - self._initial_bearing_to_target) % 360
         # offset_angle = 360 - offset_angle if offset_angle > 180 else offset_angle
 

--- a/src/eel/eel/navigation/assignments.py
+++ b/src/eel/eel/navigation/assignments.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from math import sin, radians
 from typing import Callable, TypedDict
 from time import time
 from .common import (
@@ -8,6 +9,15 @@ from .common import (
     get_next_rudder_turn,
     TOLERANCE_IN_METERS,
 )
+from ..utils.nav import get_closest_turn_direction
+
+
+def cap_value(value, floor, ceiling):
+    if value > max([ceiling, floor]):
+        return max([ceiling, floor])
+    elif value < min([ceiling, floor]):
+        return min([ceiling, floor])
+    return value
 
 
 class AssignmentProgress(TypedDict):
@@ -41,6 +51,7 @@ class WaypointAndDepth(Assignment):
     def __init__(
         self,
         target_pos: LatLon,
+        start_pos: LatLon,
         depth: float,
         on_set_motor: Callable[[float], None],
         on_set_rudder: Callable[[float], None],
@@ -52,6 +63,7 @@ class WaypointAndDepth(Assignment):
         self.on_set_motor = on_set_motor
         self.on_set_rudder = on_set_rudder
         self.on_set_depth = on_set_depth
+        self._initial_bearing_to_target = get_relative_bearing(start_pos, target_pos)
 
     def step(
         self,
@@ -68,7 +80,26 @@ class WaypointAndDepth(Assignment):
 
         bearing_to_target = get_relative_bearing(current_position, self.target_pos)
 
-        next_rudder_turn = get_next_rudder_turn(current_heading, bearing_to_target)
+        # Desired = Bearing of path - min(corrective turn angel, 90)
+        offset_angle = abs(bearing_to_target - self._initial_bearing_to_target) % 360
+        offset_angle = (
+            360 - offset_angle
+            if offset_angle > 180
+            else offset_angle
+        )
+
+        closest_turn = get_closest_turn_direction(self._initial_bearing_to_target, bearing_to_target)
+        offset = closest_turn * offset_angle
+
+        print(f"Calculated offset is: {offset}")
+
+        cross_track_error = sin(radians(offset)) * distance_to_target
+        next_rudder_turn = cap_value(cross_track_error * 0.05, -1.0, 1.0)
+        
+        print(f"Cross track error: {cross_track_error}m")
+        print(f"Next rudder turn: {next_rudder_turn}")
+
+        #next_rudder_turn = get_next_rudder_turn(current_heading, bearing_to_target)
         self.on_set_rudder(next_rudder_turn)
         return {"distance_to_target": distance_to_target}
 
@@ -84,6 +115,7 @@ class SurfaceAssignment(Assignment):
     def __init__(
         self,
         target_pos: LatLon,
+        start_pos: LatLon,
         depth: float,
         on_set_motor: Callable[[float], None],
         on_set_rudder: Callable[[float], None],
@@ -97,6 +129,7 @@ class SurfaceAssignment(Assignment):
         self.on_set_depth = on_set_depth
         self.last_update_at = time()
         self.seconds_at_surface = 0.0
+        self._initial_bearing_to_target = get_relative_bearing(start_pos, target_pos)
 
     def start(self) -> None:
         self.on_set_depth(0.0)
@@ -125,6 +158,17 @@ class SurfaceAssignment(Assignment):
         bearing_to_target = get_relative_bearing(current_position, self.target_pos)
 
         next_rudder_turn = get_next_rudder_turn(current_heading, bearing_to_target)
+        
+        print(f"Bearing to target: {bearing_to_target}")
+        print(f"Distance to target: {distance_to_target}")
+        print(f"Inital bearing to target: {self._initial_bearing_to_target}")
+
+        offset_angle = bearing_to_target - self._initial_bearing_to_target
+
+        print(f"Angle offset: {offset_angle}")
+
+        # drift_in_meters = 
+        
         self.on_set_rudder(next_rudder_turn)
         self.last_update_at = time()
         return {"distance_to_target": distance_to_target}

--- a/src/eel/eel/navigation/navigation_action_server.py
+++ b/src/eel/eel/navigation/navigation_action_server.py
@@ -156,6 +156,10 @@ class NavigationActionServer(Node):
                     lat=goal_request.next_coordinate.lat,
                     lon=goal_request.next_coordinate.lon,
                 ),
+                start_pos=LatLon(
+                    lat=self.current_position.lat,
+                    lon=self.current_position.lon,
+                ),
                 depth=(
                     0.0
                     if len(goal_request.next_coordinate_depth) == 0
@@ -170,6 +174,10 @@ class NavigationActionServer(Node):
                 target_pos=LatLon(
                     lat=goal_request.next_coordinate.lat,
                     lon=goal_request.next_coordinate.lon,
+                ),
+                start_pos=LatLon(
+                    lat=self.current_position.lat,
+                    lon=self.current_position.lon,
                 ),
                 depth=0.0,
                 on_set_motor=self.publish_motor_cmd,

--- a/src/eel/eel/utils/topics.py
+++ b/src/eel/eel/utils/topics.py
@@ -11,6 +11,8 @@ GNSS_STATUS = "gnss/status"
 
 # Localization
 LOCALIZATION_STATUS = "localization/status"
+LOCALIZATION_DRIFT_SPEED = "localization/drift_speed"
+LOCALIZATION_DRIFT_BEARING = "localization/drift_bearing"
 
 # IMU
 IMU_STATUS = "imu/status"

--- a/src/eel/test/eel/localization/localizer_test.py
+++ b/src/eel/test/eel/localization/localizer_test.py
@@ -148,6 +148,7 @@ def test__when_moving_from_two_very_distant_knowns__distance_traveled_should_not
     instance_to_test.get_calculated_position(time.time() + 20.0)
 
     actual = round(instance_to_test.get_total_meters_traveled(), 1)
+    assert math.isclose(a=actual, b=20, rel_tol=0.01)
     assert actual == 20
 
 
@@ -183,19 +184,26 @@ def test__when_speed_zero_and_drift_one_mps_should_give_new_position() -> None:
     instance_to_test = Localizer(start_time_sec=0)
     instance_to_test.update_known_position({"lat": 0, "lon": 0})
     instance_to_test.update_drift_speed_mps(1.0)
-    instance_to_test.update_drift_bearing(90.0) # Should be east bound
+    instance_to_test.update_drift_bearing(90.0)  # Should be east bound
     position_after_one_sec = instance_to_test.get_calculated_position(1.0)
 
-    assert position_after_one_sec and not positions_are_close({"lat": 0, "lon": 0}, position_after_one_sec)
+    assert position_after_one_sec and not positions_are_close(
+        {"lat": 0, "lon": 0}, position_after_one_sec
+    )
 
-def test__when_speed_zero_and_drift_one_mps_should_drift_one_meter_after_one_second() -> None:
+
+def test__when_speed_zero_and_drift_one_mps_should_drift_one_meter_after_one_second() -> (
+    None
+):
     instance_to_test = Localizer(start_time_sec=0)
     instance_to_test.update_known_position({"lat": 0, "lon": 0})
     instance_to_test.update_drift_speed_mps(1.0)
-    instance_to_test.update_drift_bearing(90.0) # Should be east bound
+    instance_to_test.update_drift_bearing(90.0)  # Should be east bound
     position_after_one_sec = instance_to_test.get_calculated_position(1.0)
 
-    assert position_after_one_sec and positions_are_close({"lat": 0.0, "lon": 8.9831528e-06}, position_after_one_sec)
+    assert position_after_one_sec and positions_are_close(
+        {"lat": 0.0, "lon": 8.9831528e-06}, position_after_one_sec
+    )
 
 
 def test__when_speed_zero_and_drift_zero_mps_should_not_drift() -> None:
@@ -203,4 +211,6 @@ def test__when_speed_zero_and_drift_zero_mps_should_not_drift() -> None:
     instance_to_test.update_known_position({"lat": 0, "lon": 0})
     position_after_one_sec = instance_to_test.get_calculated_position(1.0)
 
-    assert position_after_one_sec and positions_are_close({"lat": 0.0, "lon": 0.0}, position_after_one_sec)
+    assert position_after_one_sec and positions_are_close(
+        {"lat": 0.0, "lon": 0.0}, position_after_one_sec
+    )

--- a/src/eel/test/eel/localization/localizer_test.py
+++ b/src/eel/test/eel/localization/localizer_test.py
@@ -177,3 +177,30 @@ def test__when_depth_is_three_decimeters__should_discard_gps_position() -> None:
     assert position_before_dive and positions_are_close(
         position_before_dive, position_after_dive
     ), "position should not have changed, since gps should be discarded during dive"
+
+
+def test__when_speed_zero_and_drift_one_mps_should_give_new_position() -> None:
+    instance_to_test = Localizer(start_time_sec=0)
+    instance_to_test.update_known_position({"lat": 0, "lon": 0})
+    instance_to_test.update_drift_speed_mps(1.0)
+    instance_to_test.update_drift_bearing(90.0) # Should be east bound
+    position_after_one_sec = instance_to_test.get_calculated_position(1.0)
+
+    assert position_after_one_sec and not positions_are_close({"lat": 0, "lon": 0}, position_after_one_sec)
+
+def test__when_speed_zero_and_drift_one_mps_should_drift_one_meter_after_one_second() -> None:
+    instance_to_test = Localizer(start_time_sec=0)
+    instance_to_test.update_known_position({"lat": 0, "lon": 0})
+    instance_to_test.update_drift_speed_mps(1.0)
+    instance_to_test.update_drift_bearing(90.0) # Should be east bound
+    position_after_one_sec = instance_to_test.get_calculated_position(1.0)
+
+    assert position_after_one_sec and positions_are_close({"lat": 0.0, "lon": 8.9831528e-06}, position_after_one_sec)
+
+
+def test__when_speed_zero_and_drift_zero_mps_should_not_drift() -> None:
+    instance_to_test = Localizer(start_time_sec=0)
+    instance_to_test.update_known_position({"lat": 0, "lon": 0})
+    position_after_one_sec = instance_to_test.get_calculated_position(1.0)
+
+    assert position_after_one_sec and positions_are_close({"lat": 0.0, "lon": 0.0}, position_after_one_sec)

--- a/src/eel/test/eel/localization/localizer_test.py
+++ b/src/eel/test/eel/localization/localizer_test.py
@@ -149,7 +149,6 @@ def test__when_moving_from_two_very_distant_knowns__distance_traveled_should_not
 
     actual = round(instance_to_test.get_total_meters_traveled(), 1)
     assert math.isclose(a=actual, b=20, rel_tol=0.01)
-    assert actual == 20
 
 
 def positions_are_close(pos_1: LatLon, pos_2: LatLon) -> bool:


### PR DESCRIPTION
This works quite well. We just want to test it live, and if it works we can clean up and merge this.

One thing we can consider is: when we miss more than one target, we can call the first one done, but the second one will get its new desired bearing as the one between the vehicle and the next waypoint. This means that we can't call more than one waypoint as done at once. We will always turn back for the second one. If that is desired or not, we don't know. :smiling_face_with_tear: 