### PR TITLE
Feature: Add offset support for rudders

### DIFF
--- a/src/eel/eel/rudder/actuator/actuator.py
+++ b/src/eel/eel/rudder/actuator/actuator.py
@@ -18,6 +18,7 @@ default_x_options: ServoOptions = {
     "flip_direction": True,
     "cap_min": -0.75,
     "cap_max": 0.75,
+    "offset": 0.0  # Offset value should be as max_cap > value < min_cap
 }
 default_y_options: ServoOptions = {
     "pin": 19,
@@ -26,6 +27,7 @@ default_y_options: ServoOptions = {
     "flip_direction": False,
     "cap_min": -0.75,
     "cap_max": 0.75,
+    "offset": 0.0  # Offset value should be as max_cap > value < min_cap
 }
 
 

--- a/src/eel/eel/rudder/actuator/actuator.py
+++ b/src/eel/eel/rudder/actuator/actuator.py
@@ -33,8 +33,12 @@ default_y_options: ServoOptions = {
 
 def get_xy_rudder(options: ActuatorOptions) -> XYRudder:
     if options["simulate"]:
-        return XYRudderSim()
+        return XYRudderSim(
+            x_options=default_x_options,
+            y_options=default_y_options,)
+    
     options = cast(ActuatorOptions, options)
+    
     return XYRudderWithServos(
         x_options=default_x_options,
         y_options=default_y_options,

--- a/src/eel/eel/rudder/actuator/actuator.py
+++ b/src/eel/eel/rudder/actuator/actuator.py
@@ -18,7 +18,7 @@ default_x_options: ServoOptions = {
     "flip_direction": True,
     "cap_min": -0.75,
     "cap_max": 0.75,
-    "offset": 0.0  # Offset value should be as max_cap > value < min_cap
+    "offset": -0.10  # Offset value should be as max_cap > value < min_cap
 }
 default_y_options: ServoOptions = {
     "pin": 19,

--- a/src/eel/eel/rudder/actuator/general_servo.py
+++ b/src/eel/eel/rudder/actuator/general_servo.py
@@ -1,3 +1,4 @@
+from typing import Union
 from gpiozero import Servo
 from gpiozero.pins.pigpio import PiGPIOFactory
 from time import sleep
@@ -7,7 +8,7 @@ from .types import ServoOptions
 logger = get_logger(__name__)
 
 
-def create_pigpio_factory(host: str, retries: int, sleep_time: int) -> PiGPIOFactory:
+def create_pigpio_factory(host: str, retries: int, sleep_time: int) -> Union[PiGPIOFactory, None]:
     attempts = 0
     factory = None
     while attempts < retries and factory is None:

--- a/src/eel/eel/rudder/actuator/general_servo.py
+++ b/src/eel/eel/rudder/actuator/general_servo.py
@@ -51,8 +51,10 @@ class RudderServo:
             corrected_value = self.cap_max
         if corrected_value < self.cap_min:
             corrected_value = self.cap_min
+
         if self.flip_direction:
-            corrected_value = -value
+            corrected_value = -corrected_value
+
         self.servo.value = corrected_value
 
     # This method will not contain any checks against max/min cap, this should be 

--- a/src/eel/eel/rudder/actuator/general_servo.py
+++ b/src/eel/eel/rudder/actuator/general_servo.py
@@ -40,17 +40,34 @@ class RudderServo:
         self.flip_direction = options["flip_direction"]
         self.cap_min = options["cap_min"]
         self.cap_max = options["cap_max"]
+        self.offset = options["offset"]
 
     # We want -1 to be left and 1 to be right, but for some reason it has been
     # flipped on the servo. So we just flip it back by setting it to its inverse.
     def set_value(self, value):
-        if value > self.cap_max:
-            value = self.cap_max
-        if value < self.cap_min:
-            value = self.cap_min
+        corrected_value = value + self.offset
+
+        if corrected_value > self.cap_max:
+            corrected_value = self.cap_max
+        if corrected_value < self.cap_min:
+            corrected_value = self.cap_min
         if self.flip_direction:
-            value = -value
-        self.servo.value = value
+            corrected_value = -value
+        self.servo.value = corrected_value
+
+    # This method will not contain any checks against max/min cap, this should be 
+    # handled in the rudder node
+    def set_offset_value(self, value):
+        self.offset = value
+
+    def get_offset_value(self):
+        return self.offset
+
+    def get_cap_min_value(self):
+        return self.cap_min
+    
+    def get_cap_max_value(self):
+        return self.cap_max
 
     def detach(self):
         self.servo.detach()

--- a/src/eel/eel/rudder/actuator/types.py
+++ b/src/eel/eel/rudder/actuator/types.py
@@ -13,3 +13,4 @@ class ServoOptions(TypedDict):
     flip_direction: bool
     cap_min: float
     cap_max: float
+    offset: float

--- a/src/eel/eel/rudder/actuator/xy_rudder_base.py
+++ b/src/eel/eel/rudder/actuator/xy_rudder_base.py
@@ -7,6 +7,38 @@ class XYRudder(ABC):
     @abstractmethod
     def set_rudder(self, value: Vector2d) -> None:
         pass
+    
+    @abstractmethod
+    def get_x_rudder_offset_value(self) -> float:
+        pass
+    
+    @abstractmethod
+    def get_y_rudder_offset_value(self) -> float:
+        pass
+    
+    @abstractmethod
+    def get_x_rudder_cap_max_value(self) -> float:
+        pass
+
+    @abstractmethod
+    def get_x_rudder_cap_min_value(self) -> float:
+        pass
+    
+    @abstractmethod
+    def get_y_rudder_cap_max_value(self) -> float:
+        pass
+    
+    @abstractmethod
+    def get_y_rudder_cap_min_value(self) -> float:
+        pass
+
+    @abstractmethod
+    def set_x_rudder_offset_value(self, value: float) -> None:
+        pass
+    
+    @abstractmethod
+    def set_y_rudder_offset_value(self, value: float) -> None:
+        pass
 
     @abstractmethod
     def shutdown(self) -> None:

--- a/src/eel/eel/rudder/actuator/xy_rudder_sim.py
+++ b/src/eel/eel/rudder/actuator/xy_rudder_sim.py
@@ -1,10 +1,45 @@
-from .types import Vector2d
+from .types import ServoOptions, Vector2d
 from .xy_rudder_base import XYRudder
 
 
 class XYRudderSim(XYRudder):
+    def __init__(self, x_options: ServoOptions, y_options: ServoOptions) -> None:
+        
+        self.x_servo_offset = x_options.get("offset")
+        self.x_servo_cap_min = x_options.get("cap_min")
+        self.x_servo_cap_max = x_options.get("cap_max")
+
+
+        self.y_servo_offset = y_options.get("offset")
+        self.y_servo_cap_min = y_options.get("cap_min")
+        self.y_servo_cap_max = y_options.get("cap_max")
+
     def set_rudder(self, value: Vector2d) -> None:
         pass
+
+    def set_x_rudder_offset_value(self, value: float) -> None:
+        self.x_servo_offset = value
+    
+    def get_x_rudder_offset_value(self):
+        return self.x_servo_offset
+
+    def get_x_rudder_cap_min_value(self):
+        return self.x_servo_cap_min
+    
+    def get_x_rudder_cap_max_value(self):
+        return self.x_servo_cap_max
+    
+    def set_y_rudder_offset_value(self, value: float) -> None:
+        self.y_servo_offset = value
+
+    def get_y_rudder_offset_value(self):
+        return self.y_servo_offset
+
+    def get_y_rudder_cap_min_value(self):
+        return self.y_servo_cap_min
+    
+    def get_y_rudder_cap_max_value(self):
+        return self.y_servo_cap_max
 
     def shutdown(self) -> None:
         pass

--- a/src/eel/eel/rudder/actuator/xy_rudder_with_servos.py
+++ b/src/eel/eel/rudder/actuator/xy_rudder_with_servos.py
@@ -25,6 +25,30 @@ class XYRudderWithServos(XYRudder):
         self.x_servo.set_value(value=value["x"])
         self.y_servo.set_value(value=value["y"])
 
+    def set_x_rudder_offset_value(self, value: float) -> None:
+        self.x_servo.set_offset_value(value)
+    
+    def get_x_rudder_offset_value(self):
+        return self.x_servo.get_offset_value()
+
+    def get_x_rudder_cap_min_value(self):
+        return self.x_servo.get_cap_min_value()
+    
+    def get_x_rudder_cap_max_value(self):
+        return self.x_servo.get_cap_max_value()
+    
+    def set_y_rudder_offset_value(self, value: float) -> None:
+        self.y_servo.set_offset_value(value)
+
+    def get_y_rudder_offset_value(self):
+        return self.y_servo.get_offset_value()
+
+    def get_y_rudder_cap_min_value(self):
+        return self.y_servo.get_cap_min_value()
+    
+    def get_y_rudder_cap_max_value(self):
+        return self.y_servo.get_cap_max_value()    
+
     def shutdown(self) -> None:
         self.x_servo.detach()
         self.y_servo.detach()

--- a/src/eel/eel/rudder/rudder_node.py
+++ b/src/eel/eel/rudder/rudder_node.py
@@ -7,18 +7,28 @@ from std_msgs.msg import Float32
 import math
 import sys
 import signal
+from enum import Enum
 from eel_interfaces.msg import ImuStatus
 
 from ..utils.topics import (
     RUDDER_STATUS,
     RUDDER_X_CMD,
+    RUDDER_X_SET_OFFSET,
+    RUDDER_X_OFFSET,
     RUDDER_Y_CMD,
+    RUDDER_Y_SET_OFFSET,
+    RUDDER_Y_OFFSET,
     IMU_STATUS,
 )
 from ..utils.constants import SIMULATE_PARAM
 from ..utils.utils import clamp
 from .actuator.actuator import get_xy_rudder
 from .actuator.types import Vector2d
+
+
+class Rudders(Enum):
+    RUDDER_X = 1
+    RUDDER_Y = 2
 
 
 def rotate_vector(vector: Vector2d, rotation_degrees: float) -> Vector2d:
@@ -36,6 +46,7 @@ class Rudder(Node):
 
         self.declare_parameter(SIMULATE_PARAM, False)
         self.should_simulate = bool(self.get_parameter(SIMULATE_PARAM).value)
+        self.logger = self.get_logger()
 
         pigpiod_host_parameter = "pigpiod_host"
         self.declare_parameter(pigpiod_host_parameter, "localhost")
@@ -44,9 +55,17 @@ class Rudder(Node):
         self.x_subscription = self.create_subscription(
             Float32, RUDDER_X_CMD, self.handle_x_cmd, 10
         )
+        self.x_offset_subscription = self.create_subscription(
+            Float32, RUDDER_X_SET_OFFSET, self.handle_x_offset, 10
+        )
+        self.x_offset_publisher = self.create_publisher(Float32, RUDDER_X_OFFSET, 10)
         self.y_subscription = self.create_subscription(
             Float32, RUDDER_Y_CMD, self.handle_y_cmd, 10
         )
+        self.y_offset_subscription = self.create_subscription(
+            Float32, RUDDER_Y_SET_OFFSET, self.handle_y_offset, 10
+        )
+        self.y_offset_publisher = self.create_publisher(Float32, RUDDER_Y_OFFSET, 10)
         self.rudder_status_publisher = self.create_publisher(Vector3, RUDDER_STATUS, 10)
 
         self.imu_subscription = self.create_subscription(
@@ -63,12 +82,16 @@ class Rudder(Node):
             {"simulate": self.should_simulate, "pigpiod_host": self.pigpiod_host}
         )
 
-        self.get_logger().info(
+        self.logger.info(
             "{}Rudder node started.".format("SIMULATE " if self.should_simulate else "")
         )
 
+        # Send the initial offset values for rudder x and y for front end to pick up
+        self.publish_rudder_offset_value(Rudders.RUDDER_X)
+        self.publish_rudder_offset_value(Rudders.RUDDER_Y)
+
     def shutdown(self):
-        self.get_logger().info("Rudder node shutting down...")
+        self.logger.info("Rudder node shutting down...")
         self.xy_rudder.shutdown()
 
     def _handle_imu_msg(self, msg: ImuStatus):
@@ -79,9 +102,53 @@ class Rudder(Node):
         self.current_x_cmd = msg.data
         self.merge_and_handle_commands()
 
+    def publish_rudder_offset_value(self, rudder_type) -> None:
+        if rudder_type == Rudders.RUDDER_X:
+            offset_value = self.xy_rudder.get_x_rudder_offset_value()
+            publisher = self.x_offset_publisher
+        elif rudder_type == Rudders.RUDDER_Y:
+            offset_value = self.xy_rudder.get_y_rudder_offset_value()
+            publisher = self.y_offset_publisher
+        else:
+            self.logger.warning(f"Invalid rudder type {rudder_type}, valid types are {Rudders}")
+            return
+
+        rudder_offset_msg = Float32()
+        rudder_offset_msg.data = float(offset_value)
+        publisher.publish(rudder_offset_msg)
+
+    def handle_x_offset(self, msg:Float32) -> None:
+        offset_value_to_low = msg.data < self.xy_rudder.get_x_rudder_cap_min_value()
+        offset_value_to_high = msg.data > self.xy_rudder.get_x_rudder_cap_max_value()
+
+        if any[offset_value_to_high, offset_value_to_low]:
+            self.logger.warning(f"Requested x offset value {msg.data} is outside of boundries")
+            return
+
+        self.logger.info(f"Rudder x offset value set to {msg.data}")
+        self.xy_rudder.set_x_rudder_offset_value(msg.data)
+
+        self.publish_rudder_offset_value(Rudders.RUDDER_X)
+    
+    def publish_x_rudder_offset_value(self) -> None:
+        pass
+    
     def handle_y_cmd(self, msg: Float32) -> None:
         self.current_y_cmd = msg.data
         self.merge_and_handle_commands()
+    
+    def handle_y_offset(self, msg:Float32) -> None:
+        offset_value_to_low = msg.data < self.xy_rudder.get_y_rudder_cap_min_value()
+        offset_value_to_high = msg.data > self.xy_rudder.get_y_rudder_cap_max_value()
+
+        if any[offset_value_to_high, offset_value_to_low]:
+            self.logger.warning(f"Requested y offset value {msg.data} is outside of boundries")
+            return
+
+        self.logger.info(f"Rudder y offset value set to {msg.data}")
+        self.xy_rudder.set_x_rudder_offset_value(msg.data)
+    
+        self.publish_rudder_offset_value(Rudders.RUDDER_Y)
 
     def merge_and_handle_commands(self) -> None:
         direction: Vector2d = {

--- a/src/eel/eel/rudder/rudder_node.py
+++ b/src/eel/eel/rudder/rudder_node.py
@@ -121,7 +121,7 @@ class Rudder(Node):
         offset_value_to_low = msg.data < self.xy_rudder.get_x_rudder_cap_min_value()
         offset_value_to_high = msg.data > self.xy_rudder.get_x_rudder_cap_max_value()
 
-        if any[offset_value_to_high, offset_value_to_low]:
+        if any([offset_value_to_high, offset_value_to_low]):
             self.logger.warning(f"Requested x offset value {msg.data} is outside of boundries")
             return
 
@@ -141,12 +141,12 @@ class Rudder(Node):
         offset_value_to_low = msg.data < self.xy_rudder.get_y_rudder_cap_min_value()
         offset_value_to_high = msg.data > self.xy_rudder.get_y_rudder_cap_max_value()
 
-        if any[offset_value_to_high, offset_value_to_low]:
+        if any([offset_value_to_high, offset_value_to_low]):
             self.logger.warning(f"Requested y offset value {msg.data} is outside of boundries")
             return
 
         self.logger.info(f"Rudder y offset value set to {msg.data}")
-        self.xy_rudder.set_x_rudder_offset_value(msg.data)
+        self.xy_rudder.set_y_rudder_offset_value(msg.data)
     
         self.publish_rudder_offset_value(Rudders.RUDDER_Y)
 

--- a/src/eel/eel/utils/topics.py
+++ b/src/eel/eel/utils/topics.py
@@ -1,7 +1,11 @@
 # Rudder
 RUDDER_STATUS = "rudder/status"
 RUDDER_X_CMD = "rudder/cmd_x"
+RUDDER_X_SET_OFFSET = "rudder/set/offset_x"
+RUDDER_X_OFFSET = "rudder/offset_x"
 RUDDER_Y_CMD = "rudder/cmd_y"
+RUDDER_Y_SET_OFFSET = "ruddder/set/offset_y"
+RUDDER_Y_OFFSET = "rudder/offset_y"
 
 # Motor
 MOTOR_CMD = "motor/cmd"

--- a/src/eel/eel/utils/topics.py
+++ b/src/eel/eel/utils/topics.py
@@ -1,11 +1,11 @@
 # Rudder
 RUDDER_STATUS = "rudder/status"
 RUDDER_X_CMD = "rudder/cmd_x"
-RUDDER_X_SET_OFFSET = "rudder/set/offset_x"
-RUDDER_X_OFFSET = "rudder/offset_x"
+RUDDER_X_SET_OFFSET = "rudder/offset_x/cmd"
+RUDDER_X_OFFSET = "rudder/offset_x/status"
 RUDDER_Y_CMD = "rudder/cmd_y"
-RUDDER_Y_SET_OFFSET = "ruddder/set/offset_y"
-RUDDER_Y_OFFSET = "rudder/offset_y"
+RUDDER_Y_SET_OFFSET = "ruddder/offset_y/cmd"
+RUDDER_Y_OFFSET = "rudder/offset_y/status"
 
 # Motor
 MOTOR_CMD = "motor/cmd"


### PR DESCRIPTION
How to work with this changes. 

New topics

/rudder/offset_x   -  echos any new offset values for x rudder, will also publish in rudder node init method
/rudder/offset_y   -  same but for y
/rudder/set/offset_x   -  sets new offset values for 
/ruddder/set/offset_y  -  same but for y


 Sample on how to set a new x offset value for rudder.
ros2 topic pub rudder/set/offset_y std_msgs/msg/Float32 '{data: 0.20}' --once



