### PR TITLE
Update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/docker-multi-distro.yml
+++ b/.github/workflows/docker-multi-distro.yml
@@ -13,13 +13,13 @@ jobs:
         ros_distro: [humble, jazzy, lyrical]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Build for ${{ matrix.ros_distro }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           file: docker/Dockerfile.ros.${{ matrix.ros_distro }}
           platforms: linux/amd64,linux/arm64
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: sarisia/actions-status-discord@v1
+      - uses: sarisia/actions-status-discord@v1.16.0
         if: always()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_BUILD_CHANNEL }}


### PR DESCRIPTION
## Summary
- Bumps checkout, Docker build, and Discord notification actions to versions that run on Node 24
- Clears GitHub Actions Node 20 deprecation warnings in CI without changing workflow behavior

## Test plan
- [ ] CI passes for humble, jazzy, and lyrical matrix builds
- [ ] No Node 20 deprecation warnings in workflow job annotations