### PR TITLE
Add minimal agent and Copilot review guidance (#133)

### DIFF
--- a/.cursor/rules/eel.mdc
+++ b/.cursor/rules/eel.mdc
@@ -1,0 +1,28 @@
+---
+description: Minimal eel project conventions for agents
+alwaysApply: true
+---
+
+# Eel conventions
+
+## Project board
+
+Backlog: https://github.com/orgs/foxpoint-se/projects/1  
+When creating a GitHub issue, add it to that board.
+
+## Commits
+
+Use conventional commits. Messages focus on **why / value / purpose**, not a file changelog.  
+Bad: `update README`, `remove unused file`.  
+Good: what improved, or why the change was needed.
+
+## Scope
+
+Stay on the asked task. Don’t expand the PR or invent unrelated work.  
+Don’t create or rewrite markdown/docs unless asked.
+
+## Code style
+
+Prefer short, clearly named functions — the call chain should read as the story.  
+Don’t bury non-trivial logic in long bodies; extract into helpers, modules, or classes.  
+Match the style of nearby code.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,12 @@
+# Copilot review (eel)
+
+## PR reviews — one pass preferred
+
+Review the **full PR as it stands**, including earlier discussion on the same PR when relevant.
+
+Put **all substantive findings in one review** where possible. Prefer:
+- Batch related nits
+- Skip repeats of already-fixed or already-discussed issues
+- Don’t reopen the same class of comment after each small follow-up commit unless something new is wrong
+
+Avoid long multi-round ping-pong on polish. If a fix looks good enough, say so and stop.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent guidance (eel)
+
+## Project board
+
+Backlog: https://github.com/orgs/foxpoint-se/projects/1  
+When creating a GitHub issue, add it to that board.
+
+## Commits
+
+Use conventional commits. Write messages for **why / value / purpose**, not a file changelog.  
+Bad: `update README`, `remove unused file`.  
+Good: what improved, or why the change was needed.
+
+## Scope
+
+Stay on the asked task. Don’t expand the PR or invent unrelated work.  
+Don’t create or rewrite markdown/docs unless asked.
+
+## Code style
+
+Prefer short, clearly named functions — the call chain should read as the story.  
+Don’t bury non-trivial logic in long bodies; extract into helpers, modules, or classes.  
+Match the style of nearby code.


### PR DESCRIPTION
## Summary
- Add shared `AGENTS.md` and Cursor rule (`.cursor/rules/eel.mdc`) with bare-bone conventions: board, commit messages, focused scope, readable code.
- Add `.github/copilot-instructions.md` to steer Copilot PR review toward one thorough pass instead of long ping-pong rounds.

Closes #133.

## Test plan
- [ ] Skim the three files and confirm tone/content is short enough
- [ ] After merge, open a small follow-up PR and request Copilot review — check whether review style feels less iterative
- [ ] Creating a new issue via agent/tools still adds it to the Eel backlog board when requested