### PR TITLE
feat: centralize package version in pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ typecheck-core:
 typecheck: check-sourced typecheck-core		## Run mypy on the eel package
 
 test-checks: typecheck-core
-	python3 -m pytest src/eel/test/
+	python3 -m pytest src/eel/test/ tests/
 
 test-integration:
 	python3 -m colcon test --python-testing pytest; python3 -m colcon test-result --verbose

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ ros2 run eel imu --ros-args -p simulate:=true
 - **`[pi]`** — GPIO, sensors, actuators (boat hardware)
 - **`[dev]`** — mypy, pytest
 
+Package version lives in root `pyproject.toml`; after a manual bump run `python3 scripts/sync_version.py` to update `setup.py` and `package.xml` files.
+
 Enough for simulation. For hardware, see [Hardware bring-up](#hardware-bring-up) and the `Makefile`.
 
 ### Docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[project]
+name = "eel-workspace"
+version = "0.1.0"
+
 [tool.mypy]
 python_version = "3.10"
 strict = true

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import re
-import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -17,20 +16,40 @@ TARGETS = (
     REPO_ROOT / "src" / "eel_bringup" / "package.xml",
 )
 
+_SECTION_HEADER = re.compile(r"^\[([^\]]+)\]")
+_VERSION_ASSIGN = re.compile(r"""^version\s*=\s*(["'])([^"']+)\1\s*$""")
+
+
+def _without_comment(line: str) -> str:
+    """Drop a TOML `#` comment outside quotes (good enough for version lines)."""
+    in_single = False
+    in_double = False
+    for i, char in enumerate(line):
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif char == "#" and not in_single and not in_double:
+            return line[:i].rstrip()
+    return line.rstrip()
+
 
 def read_project_version(pyproject: Path) -> str:
     text = pyproject.read_text(encoding="utf-8")
     in_project = False
-    for line in text.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
-            in_project = stripped == "[project]"
+    for raw_line in text.splitlines():
+        line = _without_comment(raw_line).strip()
+        if not line:
+            continue
+        header = _SECTION_HEADER.fullmatch(line)
+        if header:
+            in_project = header.group(1) == "project"
             continue
         if not in_project:
             continue
-        match = re.fullmatch(r'version\s*=\s*"([^"]+)"', stripped)
+        match = _VERSION_ASSIGN.fullmatch(line)
         if match:
-            return match.group(1)
+            return match.group(2)
     raise ValueError(f"No [project].version found in {pyproject}")
 
 
@@ -66,22 +85,24 @@ def sync_package_xml(path: Path, version: str) -> bool:
     return True
 
 
+def sync_targets(version: str, targets: tuple[Path, ...] = TARGETS) -> list[Path]:
+    changed: list[Path] = []
+    for path in targets:
+        if path.suffix == ".py":
+            did_change = sync_setup_py(path, version)
+        else:
+            did_change = sync_package_xml(path, version)
+        if did_change:
+            changed.append(path)
+    return changed
+
+
 def main() -> int:
+    import sys
+
     try:
         version = read_project_version(PYPROJECT)
-    except (OSError, ValueError) as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        return 1
-
-    changed: list[Path] = []
-    try:
-        for path in TARGETS:
-            if path.suffix == ".py":
-                did_change = sync_setup_py(path, version)
-            else:
-                did_change = sync_package_xml(path, version)
-            if did_change:
-                changed.append(path)
+        changed = sync_targets(version)
     except (OSError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
@@ -96,4 +117,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -56,7 +56,7 @@ def read_project_version(pyproject: Path) -> str:
 def sync_setup_py(path: Path, version: str) -> bool:
     text = path.read_text(encoding="utf-8")
     updated, count = re.subn(
-        r'(version\s*=\s*")[^"]+(")',
+        r"""(version\s*=\s*(["']))[^"']+(\2)""",
         rf"\g<1>{version}\2",
         text,
         count=1,

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Sync package version from root pyproject.toml into setup.py and package.xml files."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+TARGETS = (
+    REPO_ROOT / "src" / "eel" / "setup.py",
+    REPO_ROOT / "src" / "eel" / "package.xml",
+    REPO_ROOT / "src" / "eel_interfaces" / "package.xml",
+    REPO_ROOT / "src" / "eel_bringup" / "package.xml",
+)
+
+
+def read_project_version(pyproject: Path) -> str:
+    text = pyproject.read_text(encoding="utf-8")
+    in_project = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_project = stripped == "[project]"
+            continue
+        if not in_project:
+            continue
+        match = re.fullmatch(r'version\s*=\s*"([^"]+)"', stripped)
+        if match:
+            return match.group(1)
+    raise ValueError(f"No [project].version found in {pyproject}")
+
+
+def sync_setup_py(path: Path, version: str) -> bool:
+    text = path.read_text(encoding="utf-8")
+    updated, count = re.subn(
+        r'(version\s*=\s*")[^"]+(")',
+        rf"\g<1>{version}\2",
+        text,
+        count=1,
+    )
+    if count != 1:
+        raise ValueError(f"Could not find version= in {path}")
+    if updated == text:
+        return False
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def sync_package_xml(path: Path, version: str) -> bool:
+    text = path.read_text(encoding="utf-8")
+    updated, count = re.subn(
+        r"(<version>)[^<]*(</version>)",
+        rf"\g<1>{version}\2",
+        text,
+        count=1,
+    )
+    if count != 1:
+        raise ValueError(f"Could not find <version> in {path}")
+    if updated == text:
+        return False
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    try:
+        version = read_project_version(PYPROJECT)
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    changed: list[Path] = []
+    try:
+        for path in TARGETS:
+            if path.suffix == ".py":
+                did_change = sync_setup_py(path, version)
+            else:
+                did_change = sync_package_xml(path, version)
+            if did_change:
+                changed.append(path)
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"version {version}")
+    if not changed:
+        print("already in sync")
+        return 0
+    for path in changed:
+        print(f"updated {path.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/eel/package.xml
+++ b/src/eel/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>eel</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>TODO: Package description</description>
   <maintainer email="adamlecorney@gmail.com">bulingen</maintainer>
   <license>TODO: License declaration</license>

--- a/src/eel/setup.py
+++ b/src/eel/setup.py
@@ -5,7 +5,7 @@ package_name = "eel"
 
 setup(
     name=package_name,
-    version="0.0.0",
+    version="0.1.0",
     packages=find_packages(),
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),

--- a/src/eel_bringup/package.xml
+++ b/src/eel_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>eel_bringup</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>TODO: Package description</description>
   <maintainer email="adamlecorney@gmail.com">ubuntu</maintainer>
   <license>TODO: License declaration</license>

--- a/src/eel_interfaces/package.xml
+++ b/src/eel_interfaces/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>eel_interfaces</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>TODO: Package description</description>
   <maintainer email="adamlecorney@gmail.com">ubuntu</maintainer>
   <license>TODO: License declaration</license>

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+SPEC = importlib.util.spec_from_file_location(
+    "sync_version", SCRIPTS_DIR / "sync_version.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+sync_version = importlib.util.module_from_spec(SPEC)
+sys.modules["sync_version"] = sync_version
+SPEC.loader.exec_module(sync_version)
+
+
+def test__when_project_header_has_comment__should_read_version(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]  # workspace\nversion = "1.2.3"  # bootstrap\n',
+        encoding="utf-8",
+    )
+
+    assert sync_version.read_project_version(pyproject) == "1.2.3"
+
+
+def test__when_version_uses_single_quotes__should_read_version(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\nversion = '2.0.0'\n", encoding="utf-8")
+
+    assert sync_version.read_project_version(pyproject) == "2.0.0"
+
+
+def test__when_setup_and_package_xml_stale__should_update_and_be_idempotent(
+    tmp_path: Path,
+) -> None:
+    setup_py = tmp_path / "setup.py"
+    package_xml = tmp_path / "package.xml"
+    setup_py.write_text('setup(\n    version="0.0.0",\n)\n', encoding="utf-8")
+    package_xml.write_text(
+        "<package>\n  <version>0.0.0</version>\n</package>\n",
+        encoding="utf-8",
+    )
+
+    changed = sync_version.sync_targets("0.1.0", (setup_py, package_xml))
+    assert changed == [setup_py, package_xml]
+    assert 'version="0.1.0"' in setup_py.read_text(encoding="utf-8")
+    assert "<version>0.1.0</version>" in package_xml.read_text(encoding="utf-8")
+
+    changed_again = sync_version.sync_targets("0.1.0", (setup_py, package_xml))
+    assert changed_again == []
+
+
+def test__when_project_version_missing__should_raise(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[tool.mypy]\npython_version = "3.10"\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"No \[project\]\.version"):
+        sync_version.read_project_version(pyproject)

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib.util
-import sys
 from pathlib import Path
 
 import pytest
@@ -10,9 +9,9 @@ SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
 SPEC = importlib.util.spec_from_file_location(
     "sync_version", SCRIPTS_DIR / "sync_version.py"
 )
-assert SPEC is not None and SPEC.loader is not None
+if SPEC is None or SPEC.loader is None:
+    raise ImportError(f"Could not load sync_version from {SCRIPTS_DIR}")
 sync_version = importlib.util.module_from_spec(SPEC)
-sys.modules["sync_version"] = sync_version
 SPEC.loader.exec_module(sync_version)
 
 
@@ -51,6 +50,17 @@ def test__when_setup_and_package_xml_stale__should_update_and_be_idempotent(
 
     changed_again = sync_version.sync_targets("0.1.0", (setup_py, package_xml))
     assert changed_again == []
+
+
+def test__when_setup_py_uses_single_quotes__should_preserve_quote_style(
+    tmp_path: Path,
+) -> None:
+    setup_py = tmp_path / "setup.py"
+    setup_py.write_text("setup(\n    version='0.0.0',\n)\n", encoding="utf-8")
+
+    changed = sync_version.sync_targets("3.1.4", (setup_py,))
+    assert changed == [setup_py]
+    assert "version='3.1.4'" in setup_py.read_text(encoding="utf-8")
 
 
 def test__when_project_version_missing__should_raise(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add `[project].version` in root `pyproject.toml` (bootstrap `0.1.0`)
- Add `scripts/sync_version.py` to propagate into `setup.py` and ROS `package.xml` files
- Document the one-line sync command in the README

Part of #144 (does not close it — Docker tags, semantic-release, Discord follow in later PRs).

## Test plan
- [x] `python3 scripts/sync_version.py` exits 0 / idempotent
- [x] Version matches across pyproject, setup.py, three package.xml
- [ ] CI `test-checks` green
- [ ] Optional: `make build` after sync with ROS sourced