### PR TITLE
feat: tag local docker images with app version

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ cd docker
 ./build-image.sh jazzy   # or: humble, lyrical
 ```
 
-Builds tag both `foxpoint/eel:<distro>` (moving) and `foxpoint/eel:<distro>-<version>` (pinned from root `pyproject.toml`). Compose / day-to-day can keep using `:jazzy`; pin a release with e.g. `:jazzy-0.1.0`.
+Builds and tags both `foxpoint/eel:<distro>` (moving) and `foxpoint/eel:<distro>-<version>` (pinned from root `pyproject.toml`). Compose / day-to-day can keep using `:jazzy`; pin a release with e.g. `:jazzy-0.1.0`.
 
 Single node in simulation:
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ cd docker
 ./build-image.sh jazzy   # or: humble, lyrical
 ```
 
+Builds tag both `foxpoint/eel:<distro>` (moving) and `foxpoint/eel:<distro>-<version>` (pinned from root `pyproject.toml`). Compose / day-to-day can keep using `:jazzy`; pin a release with e.g. `:jazzy-0.1.0`.
+
 Single node in simulation:
 
 ```bash

--- a/docker/Dockerfile.ros.humble
+++ b/docker/Dockerfile.ros.humble
@@ -2,9 +2,6 @@
 ARG ROS_DISTRO=humble
 ARG EEL_VERSION=unknown
 FROM --platform=$BUILDPLATFORM ros:${ROS_DISTRO}
-ARG EEL_VERSION
-LABEL org.opencontainers.image.version="${EEL_VERSION}"
-ENV EEL_VERSION=${EEL_VERSION}
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -52,5 +49,9 @@ RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
     colcon test --python-testing pytest && colcon test-result --verbose
 
 COPY ./docker/entrypoint.sh /entrypoint.sh
+# Version metadata last so bumps do not invalidate apt/pip/colcon layers
+ARG EEL_VERSION
+LABEL org.opencontainers.image.version="${EEL_VERSION}"
+ENV EEL_VERSION=${EEL_VERSION}
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["bash"]

--- a/docker/Dockerfile.ros.humble
+++ b/docker/Dockerfile.ros.humble
@@ -1,6 +1,10 @@
 # ROS 2 Humble (Ubuntu 22.04) Dockerfile for eel
 ARG ROS_DISTRO=humble
+ARG EEL_VERSION=unknown
 FROM --platform=$BUILDPLATFORM ros:${ROS_DISTRO}
+ARG EEL_VERSION
+LABEL org.opencontainers.image.version="${EEL_VERSION}"
+ENV EEL_VERSION=${EEL_VERSION}
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.ros.jazzy
+++ b/docker/Dockerfile.ros.jazzy
@@ -2,9 +2,6 @@
 ARG ROS_DISTRO=jazzy
 ARG EEL_VERSION=unknown
 FROM --platform=$BUILDPLATFORM ros:${ROS_DISTRO}
-ARG EEL_VERSION
-LABEL org.opencontainers.image.version="${EEL_VERSION}"
-ENV EEL_VERSION=${EEL_VERSION}
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -51,5 +48,9 @@ RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
     colcon test --python-testing pytest && colcon test-result --verbose
 
 COPY ./docker/entrypoint.sh /entrypoint.sh
+# Version metadata last so bumps do not invalidate apt/pip/colcon layers
+ARG EEL_VERSION
+LABEL org.opencontainers.image.version="${EEL_VERSION}"
+ENV EEL_VERSION=${EEL_VERSION}
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["bash"]

--- a/docker/Dockerfile.ros.jazzy
+++ b/docker/Dockerfile.ros.jazzy
@@ -1,6 +1,10 @@
 # ROS 2 Jazzy (Ubuntu 24.04) Dockerfile for eel
 ARG ROS_DISTRO=jazzy
+ARG EEL_VERSION=unknown
 FROM --platform=$BUILDPLATFORM ros:${ROS_DISTRO}
+ARG EEL_VERSION
+LABEL org.opencontainers.image.version="${EEL_VERSION}"
+ENV EEL_VERSION=${EEL_VERSION}
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.ros.lyrical
+++ b/docker/Dockerfile.ros.lyrical
@@ -1,6 +1,10 @@
 # ROS 2 Lyrical (Ubuntu 26.04) Dockerfile for eel
 ARG ROS_DISTRO=lyrical
+ARG EEL_VERSION=unknown
 FROM --platform=$BUILDPLATFORM ros:${ROS_DISTRO}
+ARG EEL_VERSION
+LABEL org.opencontainers.image.version="${EEL_VERSION}"
+ENV EEL_VERSION=${EEL_VERSION}
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.ros.lyrical
+++ b/docker/Dockerfile.ros.lyrical
@@ -2,9 +2,6 @@
 ARG ROS_DISTRO=lyrical
 ARG EEL_VERSION=unknown
 FROM --platform=$BUILDPLATFORM ros:${ROS_DISTRO}
-ARG EEL_VERSION
-LABEL org.opencontainers.image.version="${EEL_VERSION}"
-ENV EEL_VERSION=${EEL_VERSION}
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -51,5 +48,9 @@ RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
     colcon test --python-testing pytest && colcon test-result --verbose
 
 COPY ./docker/entrypoint.sh /entrypoint.sh
+# Version metadata last so bumps do not invalidate apt/pip/colcon layers
+ARG EEL_VERSION
+LABEL org.opencontainers.image.version="${EEL_VERSION}"
+ENV EEL_VERSION=${EEL_VERSION}
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["bash"]

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -3,8 +3,8 @@ set -e
 
 # Usage: ./build-image.sh <distro> [--multiarch | --ci]
 # Example: ./build-image.sh humble
-#          ./build-image.sh jazzy --multiarch
-#          ./build-image.sh humble --ci    # CI: multi-arch verify, no --load
+#          ./build-image.sh jazzy --multiarch  # multi-arch verify, no --load
+#          ./build-image.sh humble --ci        # same as --multiarch (CI)
 
 if [ -z "$1" ]; then
   echo "Usage: $0 <ros_distro> [--multiarch | --ci]"
@@ -76,7 +76,8 @@ fi
 ensure_buildx_builder
 
 if [ "$MODE" = "multiarch" ]; then
-  echo "Building multi-arch image for amd64 and arm64..."
+  # Multi-platform images cannot be --load'ed into the local docker store.
+  echo "Multi-arch verify build for linux/amd64 and linux/arm64 (no local load)..."
   docker buildx build \
     --platform linux/amd64,linux/arm64 \
     --build-arg ROS_DISTRO="${ROS_DISTRO}" \
@@ -84,9 +85,8 @@ if [ "$MODE" = "multiarch" ]; then
     -f "${DOCKERFILE}" \
     -t "${IMAGE_NAME}" \
     -t "${IMAGE_NAME_PINNED}" \
-    --load \
     ..
-  echo "Built: ${IMAGE_NAME} and ${IMAGE_NAME_PINNED} (multi-arch)"
+  echo "Multi-arch verify succeeded: ${IMAGE_NAME} and ${IMAGE_NAME_PINNED}"
 else
   ARCH=$(uname -m)
   if [ "$ARCH" = "x86_64" ]; then

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -12,7 +12,16 @@ if [ -z "$1" ]; then
 fi
 
 ROS_DISTRO="$1"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+EEL_VERSION="$(python3 -c "
+from pathlib import Path
+import sys
+sys.path.insert(0, '${REPO_ROOT}/scripts')
+from sync_version import read_project_version
+print(read_project_version(Path('${REPO_ROOT}') / 'pyproject.toml'))
+")"
 IMAGE_NAME="foxpoint/eel:${ROS_DISTRO}"
+IMAGE_NAME_PINNED="foxpoint/eel:${ROS_DISTRO}-${EEL_VERSION}"
 MODE="local"
 
 if [ "${2:-}" = "--multiarch" ]; then
@@ -44,15 +53,19 @@ ensure_buildx_builder() {
   fi
 }
 
+echo "eel version ${EEL_VERSION}"
+
 if [ "$MODE" = "ci" ]; then
   echo "CI verify build for linux/amd64 and linux/arm64 (no local load)..."
   docker buildx build \
     --platform linux/amd64,linux/arm64 \
     --build-arg ROS_DISTRO="${ROS_DISTRO}" \
+    --build-arg EEL_VERSION="${EEL_VERSION}" \
     -f "${DOCKERFILE}" \
     -t "${IMAGE_NAME}" \
+    -t "${IMAGE_NAME_PINNED}" \
     ..
-  echo "CI verify build succeeded: ${IMAGE_NAME}"
+  echo "CI verify build succeeded: ${IMAGE_NAME} and ${IMAGE_NAME_PINNED}"
   exit 0
 fi
 
@@ -63,11 +76,13 @@ if [ "$MODE" = "multiarch" ]; then
   docker buildx build \
     --platform linux/amd64,linux/arm64 \
     --build-arg ROS_DISTRO="${ROS_DISTRO}" \
+    --build-arg EEL_VERSION="${EEL_VERSION}" \
     -f "${DOCKERFILE}" \
     -t "${IMAGE_NAME}" \
+    -t "${IMAGE_NAME_PINNED}" \
     --load \
     ..
-  echo "Built: ${IMAGE_NAME} (multi-arch)"
+  echo "Built: ${IMAGE_NAME} and ${IMAGE_NAME_PINNED} (multi-arch)"
 else
   ARCH=$(uname -m)
   if [ "$ARCH" = "x86_64" ]; then
@@ -82,9 +97,11 @@ else
   docker buildx build \
     --platform "${PLATFORM}" \
     --build-arg ROS_DISTRO="${ROS_DISTRO}" \
+    --build-arg EEL_VERSION="${EEL_VERSION}" \
     -f "${DOCKERFILE}" \
     -t "${IMAGE_NAME}" \
+    -t "${IMAGE_NAME_PINNED}" \
     --load \
     ..
-  echo "Built and loaded locally: ${IMAGE_NAME} (${PLATFORM})"
+  echo "Built and loaded locally: ${IMAGE_NAME} and ${IMAGE_NAME_PINNED} (${PLATFORM})"
 fi

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -20,6 +20,10 @@ sys.path.insert(0, '${REPO_ROOT}/scripts')
 from sync_version import read_project_version
 print(read_project_version(Path('${REPO_ROOT}') / 'pyproject.toml'))
 ")"
+if [[ ! "${EEL_VERSION}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  echo "error: version '${EEL_VERSION}' is not a valid Docker tag component (use letters, digits, ., _, -)" >&2
+  exit 1
+fi
 IMAGE_NAME="foxpoint/eel:${ROS_DISTRO}"
 IMAGE_NAME_PINNED="foxpoint/eel:${ROS_DISTRO}-${EEL_VERSION}"
 MODE="local"


### PR DESCRIPTION
## Summary
- `build-image.sh` reads version from root `pyproject.toml` and tags `foxpoint/eel:<distro>` plus `foxpoint/eel:<distro>-<version>`
- Passes `EEL_VERSION` into humble/jazzy/lyrical Dockerfiles (label + env)
- README notes moving vs pinned tags

Continues #144 (does not close it).

## Test plan
- [x] Local `./docker/build-image.sh lyrical` — both tags, same IMAGE ID
- [x] `printenv EEL_VERSION` / OCI label → `0.1.0`
- [ ] CI `--ci` builds green for humble/jazzy/lyrical