### PR TITLE
chore: add semantic-release for tags and changelog on main

### DIFF
--- a/.github/workflows/docker-multi-distro.yml
+++ b/.github/workflows/docker-multi-distro.yml
@@ -38,16 +38,43 @@ jobs:
         working-directory: docker
         run: ./build-image.sh ${{ matrix.ros_distro }} --ci
 
+  release:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: [test-checks, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      released: ${{ steps.release.outputs.released || 'false' }}
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
+      release_notes: ${{ steps.release.outputs.release_notes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+      - name: Force branch to workflow sha
+        run: git reset --hard ${{ github.sha }}
+      - name: Semantic release
+        id: release
+        uses: python-semantic-release/python-semantic-release@v10.5.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          git_committer_name: "github-actions"
+          git_committer_email: "actions@users.noreply.github.com"
+
   notify:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
-    needs: [test-checks, build]
+    needs: [test-checks, build, release]
     steps:
       - uses: sarisia/actions-status-discord@v1.16.0
         if: always()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_BUILD_CHANNEL }}
-          status: ${{ (needs.test-checks.result == 'success' && needs.build.result == 'success') && 'success' || 'failure' }}
+          status: ${{ (needs.test-checks.result == 'success' && needs.build.result == 'success' && (needs.release.result == 'success' || needs.release.result == 'skipped')) && 'success' || 'failure' }}
           title: "Eel CI (checks + humble, jazzy, lyrical)"
           username: GitHub Actions
           avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# CHANGELOG
+
+<!-- version list -->

--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ ros2 run eel imu --ros-args -p simulate:=true
 - **`[pi]`** — GPIO, sensors, actuators (boat hardware)
 - **`[dev]`** — mypy, pytest
 
-Package version lives in root `pyproject.toml`; after a manual bump run `python3 scripts/sync_version.py` to update `setup.py` and `package.xml` files.
+Package version lives in root `pyproject.toml`; after a manual bump run `python3 scripts/sync_version.py` to update `setup.py` and `package.xml` files. On `main`, [python-semantic-release](https://python-semantic-release.readthedocs.io/) bumps that version from conventional commits (`feat` / `fix` / breaking); `chore` / `docs` alone do not cut a release. Dry-run locally: `pip install 'python-semantic-release>=10,<11' && semantic-release -v version --print`.
+
+### Releases
+
+After CI is green on `main`, semantic-release may create tag `vX.Y.Z`, update `CHANGELOG.md`, open a GitHub Release, and sync package versions. On the boat: `git fetch && git checkout vX.Y.Z && make build`.
 
 Enough for simulation. For hardware, see [Hardware bring-up](#hardware-bring-up) and the `Makefile`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ git add src/eel/setup.py src/eel/package.xml src/eel_interfaces/package.xml src/
 """
 
 [tool.semantic_release.branches.main]
-match = "(main)"
+match = "^main$"
 
 [tool.semantic_release.changelog]
 mode = "update"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,18 @@ ignore_missing_imports = true
 mypy_path = "src/eel:typings"
 packages = ["eel"]
 exclude = ["^build/", "^install/", "^log/", "^venv/"]
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+tag_format = "v{version}"
+commit_parser = "conventional"
+build_command = """
+python3 scripts/sync_version.py
+git add src/eel/setup.py src/eel/package.xml src/eel_interfaces/package.xml src/eel_bringup/package.xml
+"""
+
+[tool.semantic_release.branches.main]
+match = "(main)"
+
+[tool.semantic_release.changelog]
+mode = "update"


### PR DESCRIPTION
## Summary
- Configure `python-semantic-release` in root `pyproject.toml` (bumps version, runs `scripts/sync_version.py`, updates CHANGELOG)
- Add `release` job on push to `main` after tests + Docker builds (PSR v10.5.3, same pattern as nanomodem)
- Expose `released` / `version` / `tag` / `release_notes` outputs for a later Discord PR
- Document releases + local `--print` dry-run in the README

Continues #144 (does not close it).

## After merge (required once)
No `v*` tags exist yet. Immediately after merging this PR:

```bash
git checkout main && git pull
git tag -a v0.1.0 -m "v0.1.0"
git push origin v0.1.0
```

That locks the current `0.1.0` baseline so the next `fix:` / `feat:` does not scan all of history and jump versions.

## Test plan
- [x] `make test-ci` green locally
- [x] `semantic-release -v version --print` on this branch → no release (not `main`)
- [ ] CI green on the PR
- [ ] After merge: push bootstrap `v0.1.0` tag
- [ ] Later: a `fix:` PR → `v0.1.1` + CHANGELOG + GitHub Release