### PR TITLE
chore: verify semantic-release skips chore commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ ros2 run eel imu --ros-args -p simulate:=true
 - **`[pi]`** — GPIO, sensors, actuators (boat hardware)
 - **`[dev]`** — mypy, pytest
 
-Package version lives in root `pyproject.toml`; after a manual bump run `python3 scripts/sync_version.py` to update `setup.py` and `package.xml` files. On `main`, [python-semantic-release](https://python-semantic-release.readthedocs.io/) bumps that version from conventional commits (`feat` / `fix` / breaking); `chore` / `docs` alone do not cut a release. Dry-run locally: `pip install 'python-semantic-release>=10,<11' && semantic-release -v version --print`.
+Package version lives in root `pyproject.toml`. After a manual bump, run `python3 scripts/sync_version.py` to update `setup.py` and `package.xml` files.
+
+On `main`, [python-semantic-release](https://python-semantic-release.readthedocs.io/) bumps that version from conventional commits (`feat` / `fix` / breaking); `chore` / `docs` alone do not cut a release. Dry-run locally: `pip install 'python-semantic-release>=10,<11' && semantic-release -v version --print`.
 
 ### Releases
 


### PR DESCRIPTION
## Summary
- Minor README formatting (version sync paragraph split)
- **Verification PR:** merge to confirm `chore:` commits do **not** create a new release tag

## What to check after merge
- CI green on `main`
- No new `v1.0.x` tag
- `pyproject.toml` still at `1.0.0`