### PR TITLE
fix: fetch tags before checking out a release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ On `main`, [python-semantic-release](https://python-semantic-release.readthedocs
 
 ### Releases
 
-After CI is green on `main`, semantic-release may create tag `vX.Y.Z`, update `CHANGELOG.md`, open a GitHub Release, and sync package versions. On the boat: `git fetch && git checkout vX.Y.Z && make build`.
+After CI is green on `main`, semantic-release may create tag `vX.Y.Z`, update `CHANGELOG.md`, open a GitHub Release, and sync package versions. On the boat: `git fetch --tags && git checkout vX.Y.Z && make build`.
 
 Enough for simulation. For hardware, see [Hardware bring-up](#hardware-bring-up) and the `Makefile`.
 


### PR DESCRIPTION
## Summary
- README release checkout now uses `git fetch --tags` so tags are available locally
- **Verification PR:** merge to confirm `fix:` commits trigger a patch release (`v1.0.1`)

## What to check after merge
- CI green on `main`
- New tag `v1.0.1` and GitHub Release
- `CHANGELOG.md` updated with this fix
- Bot commit syncing `pyproject.toml` / package versions to `1.0.1`