### PR TITLE
feat: improve Discord CI notify for releases

### DIFF
--- a/.github/workflows/docker-multi-distro.yml
+++ b/.github/workflows/docker-multi-distro.yml
@@ -67,7 +67,7 @@ jobs:
           git_committer_email: "actions@users.noreply.github.com"
 
   notify:
-    if: ${{ github.event_name == 'push' && github.event.head_commit.author.username != 'github-actions[bot]' }}
+    if: ${{ always() && github.event_name == 'push' && github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     needs: [test-checks, build, release]
     steps:

--- a/.github/workflows/docker-multi-distro.yml
+++ b/.github/workflows/docker-multi-distro.yml
@@ -49,6 +49,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
       release_notes: ${{ steps.release.outputs.release_notes }}
+      link: ${{ steps.release.outputs.link }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -66,15 +67,37 @@ jobs:
           git_committer_email: "actions@users.noreply.github.com"
 
   notify:
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' && github.event.head_commit.author.username != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     needs: [test-checks, build, release]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Compose Discord message
+        id: discord
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TEST_CHECKS_RESULT: ${{ needs.test-checks.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          RELEASE_RESULT: ${{ needs.release.result }}
+          RELEASED: ${{ needs.release.outputs.released }}
+          VERSION: ${{ needs.release.outputs.version }}
+          RELEASE_NOTES: ${{ needs.release.outputs.release_notes }}
+          RELEASE_LINK: ${{ needs.release.outputs.link }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: python3 scripts/ci_discord_message.py
+
       - uses: sarisia/actions-status-discord@v1.16.0
         if: always()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_BUILD_CHANNEL }}
-          status: ${{ (needs.test-checks.result == 'success' && needs.build.result == 'success' && (needs.release.result == 'success' || needs.release.result == 'skipped')) && 'success' || 'failure' }}
-          title: "Eel CI (checks + humble, jazzy, lyrical)"
+          status: ${{ steps.discord.outputs.status }}
+          title: ${{ steps.discord.outputs.title }}
+          description: ${{ steps.discord.outputs.description }}
+          color: ${{ steps.discord.outputs.color }}
+          url: ${{ steps.discord.outputs.url }}
+          nodetail: true
           username: GitHub Actions
           avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"

--- a/scripts/ci_discord_message.py
+++ b/scripts/ci_discord_message.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import re
 import sys
+import uuid
 from dataclasses import dataclass
 
 COLOR_FAIL = "0xED4245"
@@ -80,7 +81,7 @@ def failed_jobs(
     }
     failed: list[str] = []
     for job, result in results.items():
-        if result == "failure":
+        if result in {"failure", "cancelled"}:
             failed.append(_JOB_LABELS[job])
     return failed
 
@@ -130,12 +131,13 @@ def build_discord_payload(
         if notes:
             parts.append(notes)
             parts.append("")
-        parts.extend([DISTROS_NOTE, f"[Full release notes →]({release_link})"])
+        notes_url = release_link or run_url
+        parts.extend([DISTROS_NOTE, f"[Full release notes →]({notes_url})"])
         return DiscordPayload(
             title=title,
             description="\n".join(parts),
             color=COLOR_SUCCESS,
-            url=release_link or run_url,
+            url=notes_url,
             status="Success",
         )
 
@@ -167,7 +169,8 @@ def _write_github_output(payload: DiscordPayload) -> None:
     }
     with open(output_path, "a", encoding="utf-8") as handle:
         for key, value in fields.items():
-            handle.write(f"{key}<<EOF\n{value}\nEOF\n")
+            delimiter = f"EOF_{uuid.uuid4().hex}"
+            handle.write(f"{key}<<{delimiter}\n{value}\n{delimiter}\n")
 
 
 def main() -> int:

--- a/scripts/ci_discord_message.py
+++ b/scripts/ci_discord_message.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Build Discord notify payload for main-branch CI workflow."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from dataclasses import dataclass
+
+COLOR_FAIL = "0xED4245"
+COLOR_SUCCESS = "0x57F287"
+DISTROS_NOTE = "Checks + docker: humble, jazzy, lyrical"
+NOTES_MAX_LEN = 500
+SUBTITLE_MAX_LEN = 120
+
+_MERGE_PR = re.compile(r"Merge pull request #(\d+)", re.IGNORECASE)
+_SQUASH_PR = re.compile(r"\(#(\d+)\)\s*$")
+
+_JOB_LABELS = {
+    "test-checks": "checks",
+    "build": "docker build",
+    "release": "release",
+}
+
+
+@dataclass(frozen=True)
+class DiscordPayload:
+    title: str
+    description: str
+    color: str
+    url: str
+    status: str
+
+
+def truncate(text: str, max_len: int) -> str:
+    stripped = text.strip()
+    if len(stripped) <= max_len:
+        return stripped
+    return stripped[: max_len - 1].rstrip() + "…"
+
+
+def first_line(message: str) -> str:
+    return message.splitlines()[0].strip() if message.strip() else ""
+
+
+def pr_number_from_message(message: str) -> str | None:
+    merge = _MERGE_PR.search(message)
+    if merge:
+        return merge.group(1)
+    squash = _SQUASH_PR.search(first_line(message))
+    if squash:
+        return squash.group(1)
+    return None
+
+
+def subtitle_link(message: str, sha: str, repo: str) -> str:
+    line = truncate(first_line(message), SUBTITLE_MAX_LEN)
+    if not line:
+        line = sha[:7]
+
+    pr_number = pr_number_from_message(message)
+    if pr_number:
+        url = f"https://github.com/{repo}/pull/{pr_number}"
+    else:
+        url = f"https://github.com/{repo}/commit/{sha}"
+
+    return f"[{line}]({url})"
+
+
+def failed_jobs(
+    test_checks: str,
+    build: str,
+    release: str,
+) -> list[str]:
+    results = {
+        "test-checks": test_checks,
+        "build": build,
+        "release": release,
+    }
+    failed: list[str] = []
+    for job, result in results.items():
+        if result == "failure":
+            failed.append(_JOB_LABELS[job])
+    return failed
+
+
+def is_success(
+    test_checks: str,
+    build: str,
+    release: str,
+) -> bool:
+    if test_checks != "success" or build != "success":
+        return False
+    return release in {"success", "skipped"}
+
+
+def build_discord_payload(
+    *,
+    test_checks: str,
+    build: str,
+    release: str,
+    released: bool,
+    version: str,
+    release_notes: str,
+    release_link: str,
+    run_url: str,
+    commit_sha: str,
+    commit_message: str,
+    repo: str,
+) -> DiscordPayload:
+    subtitle = subtitle_link(commit_message, commit_sha, repo)
+
+    if not is_success(test_checks, build, release):
+        failed = failed_jobs(test_checks, build, release)
+        failed_text = ", ".join(failed) if failed else "unknown"
+        body = f"{subtitle}\n\nFailed: {failed_text}\n{DISTROS_NOTE}"
+        return DiscordPayload(
+            title="Eel CI failed",
+            description=body,
+            color=COLOR_FAIL,
+            url=run_url,
+            status="Failure",
+        )
+
+    if released:
+        title = f"Released eel v{version}"
+        notes = truncate(release_notes, NOTES_MAX_LEN)
+        parts = [subtitle, ""]
+        if notes:
+            parts.append(notes)
+            parts.append("")
+        parts.extend([DISTROS_NOTE, f"[Full release notes →]({release_link})"])
+        return DiscordPayload(
+            title=title,
+            description="\n".join(parts),
+            color=COLOR_SUCCESS,
+            url=release_link or run_url,
+            status="Success",
+        )
+
+    version_note = f" (still v{version})" if version else ""
+    body = (
+        f"{subtitle}\n\n"
+        f"Build succeeded{version_note}\n"
+        f"{DISTROS_NOTE}"
+    )
+    return DiscordPayload(
+        title="Eel CI — no new version",
+        description=body,
+        color=COLOR_SUCCESS,
+        url=run_url,
+        status="Success",
+    )
+
+
+def _write_github_output(payload: DiscordPayload) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    fields = {
+        "title": payload.title,
+        "description": payload.description,
+        "color": payload.color,
+        "url": payload.url,
+        "status": payload.status,
+    }
+    with open(output_path, "a", encoding="utf-8") as handle:
+        for key, value in fields.items():
+            handle.write(f"{key}<<EOF\n{value}\nEOF\n")
+
+
+def main() -> int:
+    released = os.environ.get("RELEASED", "false").lower() == "true"
+    payload = build_discord_payload(
+        test_checks=os.environ.get("TEST_CHECKS_RESULT", ""),
+        build=os.environ.get("BUILD_RESULT", ""),
+        release=os.environ.get("RELEASE_RESULT", ""),
+        released=released,
+        version=os.environ.get("VERSION", ""),
+        release_notes=os.environ.get("RELEASE_NOTES", ""),
+        release_link=os.environ.get("RELEASE_LINK", ""),
+        run_url=os.environ.get("RUN_URL", ""),
+        commit_sha=os.environ.get("COMMIT_SHA", ""),
+        commit_message=os.environ.get("COMMIT_MESSAGE", ""),
+        repo=os.environ.get("GITHUB_REPOSITORY", ""),
+    )
+
+    print("Discord notify payload:")
+    print(f"  title: {payload.title}")
+    print(f"  status: {payload.status}")
+    print(f"  url: {payload.url}")
+    print(f"  description:\n{payload.description}")
+
+    _write_github_output(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci_discord_message.py
+++ b/scripts/ci_discord_message.py
@@ -121,7 +121,7 @@ def build_discord_payload(
             description=body,
             color=COLOR_FAIL,
             url=run_url,
-            status="Failure",
+            status="failure",
         )
 
     if released:
@@ -138,7 +138,7 @@ def build_discord_payload(
             description="\n".join(parts),
             color=COLOR_SUCCESS,
             url=notes_url,
-            status="Success",
+            status="success",
         )
 
     version_note = f" (still v{version})" if version else ""
@@ -152,7 +152,7 @@ def build_discord_payload(
         description=body,
         color=COLOR_SUCCESS,
         url=run_url,
-        status="Success",
+        status="success",
     )
 
 

--- a/scripts/ci_discord_message.py
+++ b/scripts/ci_discord_message.py
@@ -17,6 +17,9 @@ SUBTITLE_MAX_LEN = 120
 
 _MERGE_PR = re.compile(r"Merge pull request #(\d+)", re.IGNORECASE)
 _SQUASH_PR = re.compile(r"\(#(\d+)\)\s*$")
+_USER_MENTION = re.compile(r"<@!?(\d+)>")
+_ROLE_MENTION = re.compile(r"<@&(\d+)>")
+_ZERO_WIDTH = "\u200b"
 
 _JOB_LABELS = {
     "test-checks": "checks",
@@ -34,8 +37,20 @@ class DiscordPayload:
     status: str
 
 
+def sanitize_discord_text(text: str) -> str:
+    """Break Discord mention triggers in user-controlled text."""
+    sanitized = re.sub(r"@everyone", f"@{_ZERO_WIDTH}everyone", text, flags=re.IGNORECASE)
+    sanitized = re.sub(r"@here", f"@{_ZERO_WIDTH}here", sanitized, flags=re.IGNORECASE)
+    sanitized = _USER_MENTION.sub(f"@{_ZERO_WIDTH}user", sanitized)
+    return _ROLE_MENTION.sub(f"@{_ZERO_WIDTH}role", sanitized)
+
+
+def escape_markdown_link_label(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
+
+
 def truncate(text: str, max_len: int) -> str:
-    stripped = text.strip()
+    stripped = sanitize_discord_text(text.strip())
     if len(stripped) <= max_len:
         return stripped
     return stripped[: max_len - 1].rstrip() + "…"
@@ -56,7 +71,7 @@ def pr_number_from_message(message: str) -> str | None:
 
 
 def subtitle_link(message: str, sha: str, repo: str) -> str:
-    line = truncate(first_line(message), SUBTITLE_MAX_LEN)
+    line = escape_markdown_link_label(truncate(first_line(message), SUBTITLE_MAX_LEN))
     if not line:
         line = sha[:7]
 

--- a/tests/test_ci_discord_message.py
+++ b/tests/test_ci_discord_message.py
@@ -46,7 +46,7 @@ def test__when_all_jobs_pass_and_no_release__should_build_no_version_message() -
     payload = _payload()
 
     assert payload.title == "Eel CI — no new version"
-    assert payload.status == "Success"
+    assert payload.status == "success"
     assert payload.url == RUN_URL
     assert "Build succeeded (still v1.0.1)" in payload.description
     assert "pull/204" in payload.description
@@ -75,7 +75,7 @@ def test__when_test_checks_fail__should_list_failed_job() -> None:
     payload = _payload(test_checks="failure")
 
     assert payload.title == "Eel CI failed"
-    assert payload.status == "Failure"
+    assert payload.status == "failure"
     assert "Failed: checks" in payload.description
 
 

--- a/tests/test_ci_discord_message.py
+++ b/tests/test_ci_discord_message.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+SPEC = importlib.util.spec_from_file_location(
+    "ci_discord_message", SCRIPTS_DIR / "ci_discord_message.py"
+)
+if SPEC is None or SPEC.loader is None:
+    raise ImportError(f"Could not load ci_discord_message from {SCRIPTS_DIR}")
+ci_discord_message = importlib.util.module_from_spec(SPEC)
+import sys
+sys.modules[SPEC.name] = ci_discord_message
+SPEC.loader.exec_module(ci_discord_message)
+
+
+REPO = "foxpoint-se/eel"
+MERGE_MSG = "Merge pull request #204 from foxpoint-se/chore/verify-no-release"
+SHA = "6161e61b1043b5c5fbff66d3a5a52e79e05db745"
+RUN_URL = "https://github.com/foxpoint-se/eel/actions/runs/1"
+RELEASE_URL = "https://github.com/foxpoint-se/eel/releases/tag/v1.0.1"
+
+
+def _payload(**overrides: object) -> ci_discord_message.DiscordPayload:
+    defaults = {
+        "test_checks": "success",
+        "build": "success",
+        "release": "success",
+        "released": False,
+        "version": "1.0.1",
+        "release_notes": "",
+        "release_link": RELEASE_URL,
+        "run_url": RUN_URL,
+        "commit_sha": SHA,
+        "commit_message": MERGE_MSG,
+        "repo": REPO,
+    }
+    defaults.update(overrides)
+    return ci_discord_message.build_discord_payload(**defaults)
+
+
+def test__when_all_jobs_pass_and_no_release__should_build_no_version_message() -> None:
+    payload = _payload()
+
+    assert payload.title == "Eel CI — no new version"
+    assert payload.status == "Success"
+    assert payload.url == RUN_URL
+    assert "Build succeeded (still v1.0.1)" in payload.description
+    assert "pull/204" in payload.description
+
+
+def test__when_released__should_include_truncated_release_notes() -> None:
+    notes = "### Bug Fixes\n- Fetch tags before checking out a release\n"
+    payload = _payload(released=True, release_notes=notes)
+
+    assert payload.title == "Released eel v1.0.1"
+    assert payload.url == RELEASE_URL
+    assert "Fetch tags before checking out a release" in payload.description
+    assert "Full release notes" in payload.description
+    assert "pull/204" in payload.description
+
+
+def test__when_released_with_empty_notes__should_still_show_release_title() -> None:
+    payload = _payload(released=True, release_notes="")
+
+    assert payload.title == "Released eel v1.0.1"
+    assert "Full release notes" in payload.description
+    assert "###" not in payload.description
+
+
+def test__when_test_checks_fail__should_list_failed_job() -> None:
+    payload = _payload(test_checks="failure")
+
+    assert payload.title == "Eel CI failed"
+    assert payload.status == "Failure"
+    assert "Failed: checks" in payload.description
+
+
+def test__when_merge_commit__should_link_subtitle_to_pr() -> None:
+    link = ci_discord_message.subtitle_link(MERGE_MSG, SHA, REPO)
+
+    assert link.startswith("[Merge pull request #204")
+    assert "github.com/foxpoint-se/eel/pull/204" in link
+
+
+def test__when_squash_commit__should_link_subtitle_to_pr_from_hash_suffix() -> None:
+    message = "fix: fetch tags before checking out a release (#205)"
+    link = ci_discord_message.subtitle_link(message, SHA, REPO)
+
+    assert "pull/205" in link
+    assert "fix: fetch tags" in link
+
+
+def test__when_release_notes_long__should_truncate() -> None:
+    notes = "x" * 600
+    truncated = ci_discord_message.truncate(notes, ci_discord_message.NOTES_MAX_LEN)
+
+    assert truncated.endswith("…")
+    assert len(truncated) == ci_discord_message.NOTES_MAX_LEN
+
+
+@pytest.mark.parametrize(
+    ("message", "expected_pr"),
+    [
+        (MERGE_MSG, "204"),
+        ("fix: something (#99)", "99"),
+    ],
+)
+def test__when_message_has_pr_number__should_extract_it(
+    message: str,
+    expected_pr: str,
+) -> None:
+    assert ci_discord_message.pr_number_from_message(message) == expected_pr

--- a/tests/test_ci_discord_message.py
+++ b/tests/test_ci_discord_message.py
@@ -79,6 +79,20 @@ def test__when_test_checks_fail__should_list_failed_job() -> None:
     assert "Failed: checks" in payload.description
 
 
+def test__when_job_cancelled__should_list_cancelled_job() -> None:
+    payload = _payload(build="cancelled")
+
+    assert payload.title == "Eel CI failed"
+    assert "Failed: docker build" in payload.description
+
+
+def test__when_released_without_release_link__should_fallback_to_run_url() -> None:
+    payload = _payload(released=True, release_link="", release_notes="- fix something\n")
+
+    assert payload.url == RUN_URL
+    assert f"]({RUN_URL})" in payload.description
+
+
 def test__when_merge_commit__should_link_subtitle_to_pr() -> None:
     link = ci_discord_message.subtitle_link(MERGE_MSG, SHA, REPO)
 

--- a/tests/test_ci_discord_message.py
+++ b/tests/test_ci_discord_message.py
@@ -116,6 +116,34 @@ def test__when_release_notes_long__should_truncate() -> None:
     assert len(truncated) == ci_discord_message.NOTES_MAX_LEN
 
 
+def test__when_text_has_discord_mentions__should_neutralize() -> None:
+    text = "@everyone @here <@123456789> <@&987654321>"
+    sanitized = ci_discord_message.sanitize_discord_text(text)
+
+    assert "@everyone" not in sanitized
+    assert "@here" not in sanitized
+    assert "<@123456789>" not in sanitized
+    assert "<@&987654321>" not in sanitized
+
+
+def test__when_commit_message_has_brackets__should_escape_subtitle_label() -> None:
+    message = "fix: handle [edge case] in parser"
+    link = ci_discord_message.subtitle_link(message, SHA, REPO)
+
+    assert r"\[edge case\]" in link
+    assert link.endswith(f"](https://github.com/{REPO}/commit/{SHA})")
+
+
+def test__when_release_notes_have_mentions__should_neutralize_in_payload() -> None:
+    payload = _payload(
+        released=True,
+        release_notes="### Bug Fixes\n- fix @everyone spam\n",
+    )
+
+    assert "@everyone" not in payload.description
+    assert "everyone spam" in payload.description
+
+
 @pytest.mark.parametrize(
     ("message", "expected_pr"),
     [


### PR DESCRIPTION
## Summary
- Smart Discord embed per main push: fail / no new version / released vX.Y.Z
- Subtitle links to PR (or commit); release body includes truncated `release_notes`
- `scripts/ci_discord_message.py` + unit tests; skips bot commits

## Test plan
- [ ] CI green on this PR
- [ ] Merge `chore:` to main → green “no new version” with PR subtitle
- [ ] Merge `fix:` to main → green “Released eel vX.Y.Z” with changelog excerpt

Closes #144 (after merge + doc cleanup follow-up).