### PR TITLE
fix: show features first in Discord release summary

### DIFF
--- a/scripts/ci_discord_message.py
+++ b/scripts/ci_discord_message.py
@@ -55,8 +55,8 @@ def escape_markdown_link_label(text: str) -> str:
     return text.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
 
 
-def _section_sort_key(name: str) -> tuple[int, str]:
-    return (_SECTION_ORDER.get(name.lower(), 99), name.lower())
+def _section_sort_key(name: str) -> int:
+    return _SECTION_ORDER.get(name.lower(), 99)
 
 
 def prioritize_release_notes(notes: str) -> str:

--- a/scripts/ci_discord_message.py
+++ b/scripts/ci_discord_message.py
@@ -12,8 +12,14 @@ from dataclasses import dataclass
 COLOR_FAIL = "0xED4245"
 COLOR_SUCCESS = "0x57F287"
 DISTROS_NOTE = "Checks + docker: humble, jazzy, lyrical"
-NOTES_MAX_LEN = 500
+NOTES_MAX_LEN = 800
 SUBTITLE_MAX_LEN = 120
+
+_SECTION_ORDER = {
+    "breaking changes": 0,
+    "features": 1,
+    "bug fixes": 2,
+}
 
 _MERGE_PR = re.compile(r"Merge pull request #(\d+)", re.IGNORECASE)
 _SQUASH_PR = re.compile(r"\(#(\d+)\)\s*$")
@@ -47,6 +53,32 @@ def sanitize_discord_text(text: str) -> str:
 
 def escape_markdown_link_label(text: str) -> str:
     return text.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
+
+
+def _section_sort_key(name: str) -> tuple[int, str]:
+    return (_SECTION_ORDER.get(name.lower(), 99), name.lower())
+
+
+def prioritize_release_notes(notes: str) -> str:
+    """Put Features (and Breaking Changes) before Bug Fixes for Discord summaries."""
+    stripped = notes.strip()
+    if not stripped:
+        return stripped
+
+    parts = re.split(r"(?=^### )", stripped, flags=re.MULTILINE)
+    if len(parts) == 1:
+        return stripped
+
+    preamble = parts[0].rstrip()
+    sections = parts[1:]
+
+    def section_header(section: str) -> str:
+        first = section.splitlines()[0]
+        return first.removeprefix("### ").strip() if first.startswith("### ") else ""
+
+    sections.sort(key=lambda section: _section_sort_key(section_header(section)))
+    chunks = [chunk.strip() for chunk in ([preamble] if preamble.strip() else []) + sections]
+    return "\n\n".join(chunks) + "\n"
 
 
 def truncate(text: str, max_len: int) -> str:
@@ -141,7 +173,7 @@ def build_discord_payload(
 
     if released:
         title = f"Released eel v{version}"
-        notes = truncate(release_notes, NOTES_MAX_LEN)
+        notes = truncate(prioritize_release_notes(release_notes), NOTES_MAX_LEN)
         parts = [subtitle, ""]
         if notes:
             parts.append(notes)

--- a/tests/test_ci_discord_message.py
+++ b/tests/test_ci_discord_message.py
@@ -137,30 +137,44 @@ def test__when_release_notes_have_features_after_fixes__should_prioritize_featur
 
 
 def test__when_prioritized_release_notes_truncated__should_keep_feature_visible() -> None:
-    notes = """## v1.1.0 (2026-07-27)
+    long_fix = "- Fix something lengthy in the subsystem\n  ([`deadbeef`](https://github.com/example/commit/deadbeef))\n\n"
+    notes = f"""## v1.1.0 (2026-07-27)
 
 ### Bug Fixes
 
-- Harden Discord notify for edge cases
-  ([`a524bae`](https://github.com/example/commit/a524bae))
-
-- Sanitize Discord mentions and escape link labels
-  ([`c82d253`](https://github.com/example/commit/c82d253))
-
-- Use lowercase status for Discord action input
-  ([`de71305`](https://github.com/example/commit/de71305))
-
+{long_fix * 12}
 ### Features
 
 - Improve Discord CI notify for releases
   ([`8082e3a`](https://github.com/example/commit/8082e3a))
 """
+    prioritized = ci_discord_message.prioritize_release_notes(notes)
+    assert len(prioritized) > ci_discord_message.NOTES_MAX_LEN
+
     summary = ci_discord_message.truncate(
-        ci_discord_message.prioritize_release_notes(notes),
+        prioritized,
         ci_discord_message.NOTES_MAX_LEN,
     )
 
+    assert summary.endswith("…")
+    assert len(summary) <= ci_discord_message.NOTES_MAX_LEN
     assert "Improve Discord CI notify for releases" in summary
+
+
+def test__when_unrecognized_sections__should_preserve_relative_order() -> None:
+    notes = """## v1.0.0
+
+### Chores
+
+- chore a
+
+### Documentation
+
+- docs b
+"""
+    ordered = ci_discord_message.prioritize_release_notes(notes)
+
+    assert ordered.index("### Chores") < ordered.index("### Documentation")
 
 
 def test__when_text_has_discord_mentions__should_neutralize() -> None:

--- a/tests/test_ci_discord_message.py
+++ b/tests/test_ci_discord_message.py
@@ -109,11 +109,58 @@ def test__when_squash_commit__should_link_subtitle_to_pr_from_hash_suffix() -> N
 
 
 def test__when_release_notes_long__should_truncate() -> None:
-    notes = "x" * 600
+    notes = "x" * 900
     truncated = ci_discord_message.truncate(notes, ci_discord_message.NOTES_MAX_LEN)
 
     assert truncated.endswith("…")
     assert len(truncated) == ci_discord_message.NOTES_MAX_LEN
+
+
+def test__when_release_notes_have_features_after_fixes__should_prioritize_features() -> None:
+    notes = """## v1.1.0 (2026-07-27)
+
+### Bug Fixes
+
+- Harden Discord notify for edge cases
+  ([`a524bae`](https://github.com/example/commit/a524bae))
+
+### Features
+
+- Improve Discord CI notify for releases
+  ([`8082e3a`](https://github.com/example/commit/8082e3a))
+"""
+    ordered = ci_discord_message.prioritize_release_notes(notes)
+    features_at = ordered.index("### Features")
+    fixes_at = ordered.index("### Bug Fixes")
+
+    assert features_at < fixes_at
+
+
+def test__when_prioritized_release_notes_truncated__should_keep_feature_visible() -> None:
+    notes = """## v1.1.0 (2026-07-27)
+
+### Bug Fixes
+
+- Harden Discord notify for edge cases
+  ([`a524bae`](https://github.com/example/commit/a524bae))
+
+- Sanitize Discord mentions and escape link labels
+  ([`c82d253`](https://github.com/example/commit/c82d253))
+
+- Use lowercase status for Discord action input
+  ([`de71305`](https://github.com/example/commit/de71305))
+
+### Features
+
+- Improve Discord CI notify for releases
+  ([`8082e3a`](https://github.com/example/commit/8082e3a))
+"""
+    summary = ci_discord_message.truncate(
+        ci_discord_message.prioritize_release_notes(notes),
+        ci_discord_message.NOTES_MAX_LEN,
+    )
+
+    assert "Improve Discord CI notify for releases" in summary
 
 
 def test__when_text_has_discord_mentions__should_neutralize() -> None:


### PR DESCRIPTION
## Summary
- Reorder `release_notes` so Features (and Breaking Changes) appear before Bug Fixes before truncation
- Bump Discord changelog summary limit from 500 to 800 chars
- Commit hashes unchanged

## Test plan
- [x] Unit tests pass (`tests/test_ci_discord_message.py`)
- [ ] Merge to main; next release Discord message shows features before fixes