### PR TITLE
test: sim all-nodes startup integration test

### DIFF
--- a/.cursor/rules/eel.mdc
+++ b/.cursor/rules/eel.mdc
@@ -29,6 +29,8 @@ Prefer `chore:` / `ci:` for infra-only work that never touches application sourc
 
 **Bulk lint/format** across many source files: `feat:` or `fix:` is fine — we touch real code and a version bump is a useful marker even when behavior is unchanged.
 
+Before committing, ask: **what changelog entry should this merge produce?** Match commit type and count to that — squash PR wiring into the meaningful commit.
+
 ## Before commit
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ Prefer `chore:` / `ci:` for infra-only work that never touches application sourc
 
 **Bulk lint/format** across many source files: `feat:` or `fix:` is fine — we touch real code and a version bump is a useful marker even when behavior is unchanged.
 
+Before committing, ask: **what changelog entry should this merge produce?** Match commit type and count to that — squash PR wiring into the meaningful commit.
+
 ## Before commit
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -89,12 +89,12 @@ fix-lint:		## Apply ruff lint fixes and formatting
 	ruff format $(LINT_PATHS)
 
 test-checks: typecheck-core lint
-	python3 -m pytest src/eel/test/ tests/
+	python3 -m pytest src/eel/test/ tests/ -m "not launch_test" --ignore=src/eel/test/eel/integration
 
-test-integration:
-	python3 -m colcon test --python-testing pytest; python3 -m colcon test-result --verbose
+test-integration: check-sourced
+	python3 -m pytest src/eel/test/eel/integration/ -m launch_test -v
 
-test: check-sourced test-checks test-integration		## Run all checks and colcon tests
+test: check-sourced test-checks test-integration		## Run all checks and integration tests
 
 test-ci: test-checks		## CI: Python checks only (no ROS / venv guard)
 

--- a/docker/Dockerfile.ros.humble
+++ b/docker/Dockerfile.ros.humble
@@ -46,6 +46,7 @@ RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
     colcon build --symlink-install
 
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
+    source install/setup.bash && \
     colcon test --python-testing pytest && colcon test-result --verbose
 
 COPY ./docker/entrypoint.sh /entrypoint.sh

--- a/docker/Dockerfile.ros.jazzy
+++ b/docker/Dockerfile.ros.jazzy
@@ -45,6 +45,7 @@ RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
     colcon build --symlink-install
 
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
+    source install/setup.bash && \
     colcon test --python-testing pytest && colcon test-result --verbose
 
 COPY ./docker/entrypoint.sh /entrypoint.sh

--- a/docker/Dockerfile.ros.lyrical
+++ b/docker/Dockerfile.ros.lyrical
@@ -45,6 +45,7 @@ RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
     colcon build --symlink-install
 
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
+    source install/setup.bash && \
     colcon test --python-testing pytest && colcon test-result --verbose
 
 COPY ./docker/entrypoint.sh /entrypoint.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,8 @@ match = "^main$"
 
 [tool.semantic_release.changelog]
 mode = "update"
+
+[tool.pytest.ini_options]
+markers = [
+    "launch_test: ROS launch test (requires sourced ROS + built workspace)",
+]

--- a/src/eel/eel/dive/dive_action_client.py
+++ b/src/eel/eel/dive/dive_action_client.py
@@ -1,17 +1,25 @@
-from typing import Optional, Protocol, TypeAlias
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Protocol, TypeAlias
 
 import rclpy
 from rclpy.action import ActionClient
 from rclpy.action.client import ClientGoalHandle
 from rclpy.node import Node
 from rclpy.task import Future
-from rclpy.type_support import GetResultServiceResponse
 
 from eel_interfaces.action import Dive
 
-DiveGoalHandle: TypeAlias = ClientGoalHandle[Dive.Goal, Dive.Result, Dive.Feedback, object]
-SendGoalFuture: TypeAlias = Future[DiveGoalHandle]
-GetResultFuture: TypeAlias = Future[GetResultServiceResponse[Dive.Result]]
+if TYPE_CHECKING:
+    from rclpy.type_support import GetResultServiceResponse
+
+    DiveGoalHandle: TypeAlias = ClientGoalHandle[Dive.Goal, Dive.Result, Dive.Feedback, object]
+    SendGoalFuture: TypeAlias = Future[DiveGoalHandle]
+    GetResultFuture: TypeAlias = Future[GetResultServiceResponse[Dive.Result]]
+else:
+    DiveGoalHandle = ClientGoalHandle
+    SendGoalFuture = Future
+    GetResultFuture = Future
 
 
 class DiveFeedbackMessage(Protocol):

--- a/src/eel/eel/dive/dive_action_server.py
+++ b/src/eel/eel/dive/dive_action_server.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import time
-from typing import Optional, TypeAlias
+from typing import TYPE_CHECKING, Optional, TypeAlias
 
 import rclpy
 from rclpy.action import ActionServer, GoalResponse
@@ -17,7 +19,10 @@ from ..utils.topics import IMU_STATUS, PRESSURE_STATUS, RUDDER_Y_CMD
 
 UPDATE_FREQUENCY_PER_SEC = 5
 
-DiveGoalHandle: TypeAlias = ServerGoalHandle[Dive.Goal, Dive.Result, Dive.Feedback, object]
+if TYPE_CHECKING:
+    DiveGoalHandle: TypeAlias = ServerGoalHandle[Dive.Goal, Dive.Result, Dive.Feedback, object]
+else:
+    DiveGoalHandle = ServerGoalHandle
 
 
 class DiveActionServer(Node):

--- a/src/eel/eel/navigation/navigation_action_client.py
+++ b/src/eel/eel/navigation/navigation_action_client.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from collections import deque
 from time import time
-from typing import Deque, List, Optional, Protocol, Sequence, TypeAlias
+from typing import TYPE_CHECKING, Deque, List, Optional, Protocol, Sequence, TypeAlias
 
 import rclpy
 from action_msgs.msg import GoalStatus
@@ -8,7 +10,6 @@ from rclpy.action import ActionClient
 from rclpy.action.client import ClientGoalHandle
 from rclpy.node import Node
 from rclpy.task import Future
-from rclpy.type_support import GetResultServiceResponse
 from std_msgs.msg import Bool, String
 
 from eel_interfaces.action import Navigate
@@ -35,9 +36,16 @@ from ..utils.topics import (
 )
 from .common import get_2d_distance_from_coords
 
-NavigateGoalHandle: TypeAlias = ClientGoalHandle[Navigate.Goal, Navigate.Result, Navigate.Feedback, object]
-SendGoalFuture: TypeAlias = Future[NavigateGoalHandle]
-GetResultFuture: TypeAlias = Future[GetResultServiceResponse[Navigate.Result]]
+if TYPE_CHECKING:
+    from rclpy.type_support import GetResultServiceResponse
+
+    NavigateGoalHandle: TypeAlias = ClientGoalHandle[Navigate.Goal, Navigate.Result, Navigate.Feedback, object]
+    SendGoalFuture: TypeAlias = Future[NavigateGoalHandle]
+    GetResultFuture: TypeAlias = Future[GetResultServiceResponse[Navigate.Result]]
+else:
+    NavigateGoalHandle = ClientGoalHandle
+    SendGoalFuture = Future
+    GetResultFuture = Future
 
 
 class NavigateFeedbackMessage(Protocol):

--- a/src/eel/eel/navigation/navigation_action_server.py
+++ b/src/eel/eel/navigation/navigation_action_server.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 from time import sleep, time
-from typing import Optional, TypeAlias
+from typing import TYPE_CHECKING, Optional, TypeAlias
 
 import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
@@ -24,7 +26,10 @@ from ..utils.topics import (
 from .assignments import Assignment, SurfaceAssignment, WaypointAndDepth
 from .common import LatLon, get_2d_distance
 
-NavigateGoalHandle: TypeAlias = ServerGoalHandle[Navigate.Goal, Navigate.Result, Navigate.Feedback, object]
+if TYPE_CHECKING:
+    NavigateGoalHandle: TypeAlias = ServerGoalHandle[Navigate.Goal, Navigate.Result, Navigate.Feedback, object]
+else:
+    NavigateGoalHandle = ServerGoalHandle
 
 
 TARGET_DISTANCE_LIMIT = 2500

--- a/src/eel/eel/tank/tank_node.py
+++ b/src/eel/eel/tank/tank_node.py
@@ -128,13 +128,13 @@ class TankNode(Node):
     def __init__(self) -> None:
         super().__init__("tank_node", parameter_overrides=[])
         self.declare_parameter(SIMULATE_PARAM, False)
-        self.declare_parameter(CMD_TOPIC_PARAM)
-        self.declare_parameter(STATUS_TOPIC_PARAM)
+        self.declare_parameter(CMD_TOPIC_PARAM, "")
+        self.declare_parameter(STATUS_TOPIC_PARAM, "")
         self.declare_parameter(MOTOR_PIN_PARAM, -1)
         self.declare_parameter(DIRECTION_PIN_PARAM, -1)
         self.declare_parameter(DISTANCE_SENSOR_CHANNEL_PARAM, -1)
-        self.declare_parameter(TANK_FLOOR_VALUE_PARAM)
-        self.declare_parameter(TANK_CEILING_VALUE_PARAM)
+        self.declare_parameter(TANK_FLOOR_VALUE_PARAM, 0.0)
+        self.declare_parameter(TANK_CEILING_VALUE_PARAM, 1.0)
 
         should_simulate = bool(self.get_parameter(SIMULATE_PARAM).value)
         motor_pin = int(self.get_parameter(MOTOR_PIN_PARAM).get_parameter_value().integer_value)

--- a/src/eel/eel/tank/tank_node.py
+++ b/src/eel/eel/tank/tank_node.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import math
 import sys
 from typing import Literal, Optional
 
@@ -48,6 +49,8 @@ LEVEL_CEILING = 1.0
 # Minimum update frequency: velocity / tolerance = 1.6 / 1.05 = 1.5 hz
 # UPDATE_FREQUENCY = 10 should therefore be plenty.
 UPDATE_FREQUENCY = 10
+
+TANK_CALIBRATION_UNSET = float("nan")
 
 
 TargetStatus = Literal["target_reached", "ceiling_reached", "floor_reached", "no_target", "adjusting"]
@@ -133,8 +136,8 @@ class TankNode(Node):
         self.declare_parameter(MOTOR_PIN_PARAM, -1)
         self.declare_parameter(DIRECTION_PIN_PARAM, -1)
         self.declare_parameter(DISTANCE_SENSOR_CHANNEL_PARAM, -1)
-        self.declare_parameter(TANK_FLOOR_VALUE_PARAM, 0.0)
-        self.declare_parameter(TANK_CEILING_VALUE_PARAM, 1.0)
+        self.declare_parameter(TANK_FLOOR_VALUE_PARAM, TANK_CALIBRATION_UNSET)
+        self.declare_parameter(TANK_CEILING_VALUE_PARAM, TANK_CALIBRATION_UNSET)
 
         should_simulate = bool(self.get_parameter(SIMULATE_PARAM).value)
         motor_pin = int(self.get_parameter(MOTOR_PIN_PARAM).get_parameter_value().integer_value)
@@ -144,6 +147,9 @@ class TankNode(Node):
         )
         floor_value = float(self.get_parameter(TANK_FLOOR_VALUE_PARAM).get_parameter_value().double_value)
         ceiling_value = float(self.get_parameter(TANK_CEILING_VALUE_PARAM).get_parameter_value().double_value)
+
+        if math.isnan(floor_value) or math.isnan(ceiling_value):
+            raise TypeError(f"Missing calibration parameters ({TANK_FLOOR_VALUE_PARAM}, {TANK_CEILING_VALUE_PARAM})")
 
         self.is_autocorrecting: bool = False
         self.target_level: Optional[float] = None

--- a/src/eel/package.xml
+++ b/src/eel/package.xml
@@ -13,6 +13,10 @@
   <depend>geometry_msgs</depend>
 
   <test_depend>python3-pytest</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/src/eel/pytest.ini
+++ b/src/eel/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    launch_test: ROS launch test (requires sourced ROS + built workspace)

--- a/src/eel/pytest.ini
+++ b/src/eel/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-    launch_test: ROS launch test (requires sourced ROS + built workspace)

--- a/src/eel/test/eel/integration/test_all_sim_nodes_publish_status_on_startup.py
+++ b/src/eel/test/eel/integration/test_all_sim_nodes_publish_status_on_startup.py
@@ -78,9 +78,7 @@ def generate_test_description():
 
 class TestAllSimNodesPublishStatusOnStartup(unittest.TestCase):
     def test__when_all_sim_nodes_start__should_publish_status_on_startup(self, proc_info) -> None:
-        for _node_name, topic, msg_type in STATUS_PUBLISHERS:
-            with WaitForTopics([(topic, msg_type)], timeout=TOPIC_TIMEOUT_SEC):
-                pass
-            _assert_no_process_crashed(proc_info)
-
+        topics = [(topic, msg_type) for _node_name, topic, msg_type in STATUS_PUBLISHERS]
+        with WaitForTopics(topics, timeout=TOPIC_TIMEOUT_SEC):
+            pass
         _assert_no_process_crashed(proc_info)

--- a/src/eel/test/eel/integration/test_all_sim_nodes_publish_status_on_startup.py
+++ b/src/eel/test/eel/integration/test_all_sim_nodes_publish_status_on_startup.py
@@ -1,0 +1,93 @@
+import os
+import unittest
+from pathlib import Path
+
+import launch
+import pytest
+from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
+from eel.utils.topics import (
+    BATTERY_STATUS,
+    DEPTH_CONTROL_STATUS,
+    FRONT_TANK_STATUS,
+    IMU_STATUS,
+    LEAKAGE_STATUS,
+    MODEM_STATUS,
+    NAVIGATION_STATUS,
+    PRESSURE_STATUS,
+    REAR_TANK_STATUS,
+    RUDDER_STATUS,
+)
+from geometry_msgs.msg import Vector3
+from launch.actions import IncludeLaunchDescription
+from launch.events.process.process_exited import ProcessExited
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+from launch_testing_ros import WaitForTopics
+from std_msgs.msg import Bool
+
+from eel_interfaces.msg import (
+    BatteryStatus,
+    DepthControlStatus,
+    ImuStatus,
+    ModemStatus,
+    NavigationStatus,
+    PressureStatus,
+    TankStatus,
+)
+
+TOPIC_TIMEOUT_SEC = 20.0
+
+# Sim nodes that publish a status topic we can wait on at startup.
+STATUS_PUBLISHERS: list[tuple[str, str, type]] = [
+    ("imu_node", IMU_STATUS, ImuStatus),
+    ("battery_node", BATTERY_STATUS, BatteryStatus),
+    ("pressure_node", PRESSURE_STATUS, PressureStatus),
+    ("front_tank", FRONT_TANK_STATUS, TankStatus),
+    ("rear_tank", REAR_TANK_STATUS, TankStatus),
+    ("leakage_node", LEAKAGE_STATUS, Bool),
+    ("modem_node", MODEM_STATUS, ModemStatus),
+    ("rudder_node", RUDDER_STATUS, Vector3),
+    ("depth_control_rudder_node", DEPTH_CONTROL_STATUS, DepthControlStatus),
+    ("navigation_action_client", NAVIGATION_STATUS, NavigationStatus),
+]
+
+
+def _assert_no_process_crashed(proc_info) -> None:
+    for event in proc_info:
+        if isinstance(event, ProcessExited) and event.returncode != 0:
+            name = getattr(event.action, "name", str(event.action))
+            raise AssertionError(f"{name} exited with code {event.returncode}")
+
+
+def _sim_all_nodes_startup_launch_file() -> str:
+    launch_name = "sim_all_nodes_startup.launch.py"
+    try:
+        share_dir = get_package_share_directory("eel_bringup")
+    except PackageNotFoundError:
+        src_root = Path(__file__).resolve().parents[4]
+        return str(src_root / "eel_bringup" / "launch" / launch_name)
+    return os.path.join(share_dir, "launch", launch_name)
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    launch_file = _sim_all_nodes_startup_launch_file()
+    return (
+        launch.LaunchDescription(
+            [
+                IncludeLaunchDescription(PythonLaunchDescriptionSource(launch_file)),
+                ReadyToTest(),
+            ]
+        ),
+        {},
+    )
+
+
+class TestAllSimNodesPublishStatusOnStartup(unittest.TestCase):
+    def test__when_all_sim_nodes_start__should_publish_status_on_startup(self, proc_info) -> None:
+        for _node_name, topic, msg_type in STATUS_PUBLISHERS:
+            with WaitForTopics([(topic, msg_type)], timeout=TOPIC_TIMEOUT_SEC):
+                pass
+            _assert_no_process_crashed(proc_info)
+
+        _assert_no_process_crashed(proc_info)

--- a/src/eel/test/eel/integration/test_all_sim_nodes_publish_status_on_startup.py
+++ b/src/eel/test/eel/integration/test_all_sim_nodes_publish_status_on_startup.py
@@ -1,10 +1,9 @@
 import os
 import unittest
-from pathlib import Path
 
 import launch
 import pytest
-from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
+from ament_index_python.packages import get_package_share_directory
 from eel.utils.topics import (
     BATTERY_STATUS,
     DEPTH_CONTROL_STATUS,
@@ -59,19 +58,13 @@ def _assert_no_process_crashed(proc_info) -> None:
             raise AssertionError(f"{name} exited with code {event.returncode}")
 
 
-def _sim_all_nodes_startup_launch_file() -> str:
-    launch_name = "sim_all_nodes_startup.launch.py"
-    try:
-        share_dir = get_package_share_directory("eel_bringup")
-    except PackageNotFoundError:
-        src_root = Path(__file__).resolve().parents[4]
-        return str(src_root / "eel_bringup" / "launch" / launch_name)
-    return os.path.join(share_dir, "launch", launch_name)
-
-
 @pytest.mark.launch_test
 def generate_test_description():
-    launch_file = _sim_all_nodes_startup_launch_file()
+    launch_file = os.path.join(
+        get_package_share_directory("eel_bringup"),
+        "launch",
+        "sim_all_nodes_startup.launch.py",
+    )
     return (
         launch.LaunchDescription(
             [

--- a/src/eel/test/eel/localization/localizer_test.py
+++ b/src/eel/test/eel/localization/localizer_test.py
@@ -130,7 +130,7 @@ def test__when_one_known_and_sequence_of_moves__should_move_as_specified() -> No
 
 
 def test__when_moving_from_two_very_distant_knowns__distance_traveled_should_not_be_huge() -> None:
-    instance_to_test = Localizer()
+    instance_to_test = Localizer(start_time_sec=0)
     instance_to_test.update_known_position({"lat": 0, "lon": 0})
     instance_to_test.update_speed_mps(1.0)
     instance_to_test.update_heading(0)
@@ -138,7 +138,7 @@ def test__when_moving_from_two_very_distant_knowns__distance_traveled_should_not
 
     # known position is very far from previous
     instance_to_test.update_known_position({"lat": 20, "lon": 20})
-    instance_to_test.get_calculated_position(time.time() + 20.0)
+    instance_to_test.get_calculated_position(20)
 
     actual = round(instance_to_test.get_total_meters_traveled(), 1)
     assert math.isclose(a=actual, b=20, rel_tol=0.01)

--- a/src/eel_bringup/launch/sim_all_nodes_startup.launch.py
+++ b/src/eel_bringup/launch/sim_all_nodes_startup.launch.py
@@ -1,20 +1,22 @@
+from eel.utils.constants import (
+    CMD_TOPIC_PARAM,
+    DIRECTION_PIN_PARAM,
+    DISTANCE_SENSOR_CHANNEL_PARAM,
+    MOTOR_PIN_PARAM,
+    SIMULATE_PARAM,
+    STATUS_TOPIC_PARAM,
+    TANK_CEILING_VALUE_PARAM,
+    TANK_FLOOR_VALUE_PARAM,
+)
+from eel.utils.topics import (
+    FRONT_TANK_CMD,
+    FRONT_TANK_STATUS,
+    REAR_TANK_CMD,
+    REAR_TANK_STATUS,
+)
 from launch_ros.actions import Node
 
 from launch import LaunchDescription
-
-SIMULATE_PARAM = "simulate"
-MOTOR_PIN_PARAM = "motor_pin"
-DIRECTION_PIN_PARAM = "direction_pin"
-DISTANCE_SENSOR_CHANNEL_PARAM = "distance_sensor_channel"
-CMD_TOPIC_PARAM = "cmd_topic"
-STATUS_TOPIC_PARAM = "status_topic"
-TANK_FLOOR_VALUE_PARAM = "tank_floor_value"
-TANK_CEILING_VALUE_PARAM = "tank_ceiling_value"
-
-FRONT_TANK_CMD = "tank_front/cmd"
-FRONT_TANK_STATUS = "tank_front/status"
-REAR_TANK_CMD = "tank_rear/cmd"
-REAR_TANK_STATUS = "tank_rear/status"
 
 
 def _tank_node(

--- a/src/eel_bringup/launch/sim_all_nodes_startup.launch.py
+++ b/src/eel_bringup/launch/sim_all_nodes_startup.launch.py
@@ -1,0 +1,70 @@
+from launch_ros.actions import Node
+
+from launch import LaunchDescription
+
+SIMULATE_PARAM = "simulate"
+MOTOR_PIN_PARAM = "motor_pin"
+DIRECTION_PIN_PARAM = "direction_pin"
+DISTANCE_SENSOR_CHANNEL_PARAM = "distance_sensor_channel"
+CMD_TOPIC_PARAM = "cmd_topic"
+STATUS_TOPIC_PARAM = "status_topic"
+TANK_FLOOR_VALUE_PARAM = "tank_floor_value"
+TANK_CEILING_VALUE_PARAM = "tank_ceiling_value"
+
+FRONT_TANK_CMD = "tank_front/cmd"
+FRONT_TANK_STATUS = "tank_front/status"
+REAR_TANK_CMD = "tank_rear/cmd"
+REAR_TANK_STATUS = "tank_rear/status"
+
+
+def _tank_node(
+    name: str,
+    cmd_topic: str,
+    status_topic: str,
+    motor_pin: int,
+    direction_pin: int,
+    channel: int,
+    floor: float,
+    ceiling: float,
+) -> Node:
+    return Node(
+        package="eel",
+        executable="tank",
+        name=name,
+        parameters=[
+            {SIMULATE_PARAM: True},
+            {CMD_TOPIC_PARAM: cmd_topic},
+            {STATUS_TOPIC_PARAM: status_topic},
+            {MOTOR_PIN_PARAM: motor_pin},
+            {DIRECTION_PIN_PARAM: direction_pin},
+            {DISTANCE_SENSOR_CHANNEL_PARAM: channel},
+            {TANK_FLOOR_VALUE_PARAM: floor},
+            {TANK_CEILING_VALUE_PARAM: ceiling},
+        ],
+    )
+
+
+def generate_launch_description():
+    simulate = {SIMULATE_PARAM: True}
+
+    return LaunchDescription(
+        [
+            Node(package="eel", executable="imu", name="imu_node", parameters=[simulate]),
+            Node(package="eel", executable="motor", name="motor_node", parameters=[simulate]),
+            Node(package="eel", executable="rudder", name="rudder_node", parameters=[simulate]),
+            Node(package="eel", executable="battery", name="battery_node", parameters=[simulate]),
+            Node(package="eel", executable="pressure", name="pressure_node", parameters=[simulate]),
+            _tank_node("front_tank", FRONT_TANK_CMD, FRONT_TANK_STATUS, 23, 18, 0, 0.66, 0.16),
+            _tank_node("rear_tank", REAR_TANK_CMD, REAR_TANK_STATUS, 24, 25, 1, 0.325, 0.005),
+            Node(package="eel", executable="leakage", name="leakage_node", parameters=[simulate]),
+            Node(package="eel", executable="modem", name="modem_node", parameters=[simulate]),
+            Node(package="eel", executable="localization", name="localization"),
+            Node(package="eel", executable="navigate", name="navigation_action_server"),
+            Node(package="eel", executable="navigate_client", name="navigation_action_client"),
+            Node(package="eel", executable="depth_control_rudder", name="depth_control_rudder_node"),
+            Node(package="eel", executable="depth_control", name="depth_control_tank_node"),
+            Node(package="eel", executable="dive", name="dive_action_server"),
+            Node(package="eel", executable="dive_client", name="dive_action_client"),
+            Node(package="eel", executable="data_logger", name="data_logger_node"),
+        ]
+    )


### PR DESCRIPTION
## Summary
- Add `sim_all_nodes_startup.launch.py` to start all sim-capable nodes together
- Add launch test that waits for status topics and asserts no process crashes
- Split `make test`: unit checks via pytest; startup test via pytest locally and `colcon test` in Docker
- Fix tank node param defaults uncovered by the new test (Lyrical startup crash)

Closes #193

## Test plan
- [x] `source source_me.sh && make test` — unit + startup test pass locally
- [ ] CI `make test-ci` on PR
- [ ] Docker build runs `colcon test` on humble / jazzy / lyrical