### PR TITLE
dx: graceful Ctrl+C shutdown for Python nodes

### DIFF
--- a/src/eel/eel/battery/battery_node.py
+++ b/src/eel/eel/battery/battery_node.py
@@ -2,6 +2,7 @@
 from typing import Optional
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import BatteryStatus
@@ -50,8 +51,14 @@ class BatteryNode(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = BatteryNode()
-    rclpy.spin(node)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/battery/battery_node.py
+++ b/src/eel/eel/battery/battery_node.py
@@ -2,12 +2,12 @@
 from typing import Optional
 
 import rclpy
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import BatteryStatus
 
 from ..utils.constants import SIMULATE_PARAM
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import BATTERY_STATUS
 from .battery_sensor import BatterySensor
 from .battery_sim import BatterySimulator
@@ -51,14 +51,7 @@ class BatteryNode(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = BatteryNode()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/data_logger/data_logger_node.py
+++ b/src/eel/eel/data_logger/data_logger_node.py
@@ -4,6 +4,7 @@ from time import time
 from typing import List, Optional
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import (
@@ -111,8 +112,14 @@ class DataLogger(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     data_logger_node = DataLogger()
-    rclpy.spin(data_logger_node)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(data_logger_node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        data_logger_node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/data_logger/data_logger_node.py
+++ b/src/eel/eel/data_logger/data_logger_node.py
@@ -4,7 +4,6 @@ from time import time
 from typing import List, Optional
 
 import rclpy
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import (
@@ -15,6 +14,7 @@ from eel_interfaces.msg import (
     TracedRoute,
 )
 
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import (
     LOCALIZATION_STATUS,
     MODEM_STATUS,
@@ -112,14 +112,7 @@ class DataLogger(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     data_logger_node = DataLogger()
-
-    try:
-        rclpy.spin(data_logger_node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        data_logger_node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(data_logger_node)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/depth_control/depth_control_node.py
+++ b/src/eel/eel/depth_control/depth_control_node.py
@@ -3,7 +3,6 @@ from time import time
 from typing import Optional
 
 import rclpy
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
@@ -17,6 +16,7 @@ from eel_interfaces.msg import (
     TankStatus,
 )
 
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.pid_controller import PidController
 from ..utils.pid_tuning import get_production_pid_settings
 from ..utils.topics import (
@@ -346,14 +346,7 @@ class DepthControlNode(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = DepthControlNode()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/depth_control/depth_control_node.py
+++ b/src/eel/eel/depth_control/depth_control_node.py
@@ -3,6 +3,7 @@ from time import time
 from typing import Optional
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
@@ -345,8 +346,14 @@ class DepthControlNode(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = DepthControlNode()
-    rclpy.spin(node)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/depth_control/depth_control_node_rudder.py
+++ b/src/eel/eel/depth_control/depth_control_node_rudder.py
@@ -2,7 +2,6 @@
 from typing import Optional
 
 import rclpy
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
@@ -13,6 +12,7 @@ from eel_interfaces.msg import (
     PressureStatus,
 )
 
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.pid_controller import PidController
 from ..utils.topics import (
     DEPTH_CONTROL_CMD,
@@ -100,14 +100,7 @@ class DepthControlNode(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = DepthControlNode()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/depth_control/depth_control_node_rudder.py
+++ b/src/eel/eel/depth_control/depth_control_node_rudder.py
@@ -2,6 +2,7 @@
 from typing import Optional
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
@@ -99,8 +100,14 @@ class DepthControlNode(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = DepthControlNode()
-    rclpy.spin(node)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/dive/dive_action_server.py
+++ b/src/eel/eel/dive/dive_action_server.py
@@ -7,7 +7,7 @@ import rclpy
 from rclpy.action import ActionServer, GoalResponse
 from rclpy.action.server import ServerGoalHandle
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.executors import MultiThreadedExecutor
+from rclpy.executors import ExternalShutdownException, MultiThreadedExecutor
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
@@ -182,8 +182,14 @@ def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     dive_action_server = DiveActionServer()
     executor = MultiThreadedExecutor()
-    rclpy.spin(dive_action_server, executor=executor)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(dive_action_server, executor=executor)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        dive_action_server.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/dive/dive_action_server.py
+++ b/src/eel/eel/dive/dive_action_server.py
@@ -7,13 +7,14 @@ import rclpy
 from rclpy.action import ActionServer, GoalResponse
 from rclpy.action.server import ServerGoalHandle
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.executors import ExternalShutdownException, MultiThreadedExecutor
+from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
 from eel_interfaces.action import Dive
 from eel_interfaces.msg import ImuStatus, PressureStatus
 
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.pid_controller import PidController
 from ..utils.topics import IMU_STATUS, PRESSURE_STATUS, RUDDER_Y_CMD
 
@@ -182,14 +183,7 @@ def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     dive_action_server = DiveActionServer()
     executor = MultiThreadedExecutor()
-
-    try:
-        rclpy.spin(dive_action_server, executor=executor)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        dive_action_server.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(dive_action_server, executor=executor)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/gnss/gnss_node.py
+++ b/src/eel/eel/gnss/gnss_node.py
@@ -2,12 +2,12 @@
 from typing import Optional
 
 import rclpy
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import Coordinate
 
 from ..utils.constants import SIMULATE_PARAM
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import GNSS_STATUS
 from .gnss_sensor import GnssSensor
 
@@ -50,14 +50,7 @@ class GNSS(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = GNSS()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/gnss/gnss_node.py
+++ b/src/eel/eel/gnss/gnss_node.py
@@ -2,6 +2,7 @@
 from typing import Optional
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import Coordinate
@@ -49,8 +50,14 @@ class GNSS(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = GNSS()
-    rclpy.spin(node)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/imu/imu_node.py
+++ b/src/eel/eel/imu/imu_node.py
@@ -3,12 +3,12 @@ from time import time
 from typing import Optional
 
 import rclpy
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import ImuOffsets, ImuStatus
 
 from ..utils.constants import SIMULATE_PARAM
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import IMU_OFFSETS, IMU_STATUS
 from .imu_sensor import ImuSensor
 from .imu_sim import ImuSimulator
@@ -128,14 +128,7 @@ class ImuNode(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = ImuNode()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/imu/imu_node.py
+++ b/src/eel/eel/imu/imu_node.py
@@ -3,6 +3,7 @@ from time import time
 from typing import Optional
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import ImuOffsets, ImuStatus
@@ -127,8 +128,14 @@ class ImuNode(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = ImuNode()
-    rclpy.spin(node)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/leakage/leakage_node.py
+++ b/src/eel/eel/leakage/leakage_node.py
@@ -2,11 +2,11 @@
 from typing import Optional
 
 import rclpy
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Bool
 
 from ..utils.constants import SIMULATE_PARAM
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import LEAKAGE_STATUS
 from .leakage_source import LeakageSource
 
@@ -44,14 +44,7 @@ class Leakage(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = Leakage()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/leakage/leakage_node.py
+++ b/src/eel/eel/leakage/leakage_node.py
@@ -2,6 +2,7 @@
 from typing import Optional
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Bool
 
@@ -43,8 +44,14 @@ class Leakage(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = Leakage()
-    rclpy.spin(node)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/led_control/led_node.py
+++ b/src/eel/eel/led_control/led_node.py
@@ -2,6 +2,7 @@
 from typing import Optional
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import NavigationStatus
@@ -56,8 +57,14 @@ class LED(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = LED()
-    rclpy.spin(node)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/led_control/led_node.py
+++ b/src/eel/eel/led_control/led_node.py
@@ -2,12 +2,12 @@
 from typing import Optional
 
 import rclpy
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import NavigationStatus
 
 from ..utils.constants import NavigationMissionStatus
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import NAVIGATION_STATUS
 from .led_control import LEDControl
 
@@ -57,14 +57,7 @@ class LED(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = LED()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/localization/localization.py
+++ b/src/eel/eel/localization/localization.py
@@ -3,12 +3,12 @@ import time
 from typing import Optional
 
 import rclpy
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
 from eel_interfaces.msg import Coordinate, ImuStatus, PressureStatus
 
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.sim import LINEAR_VELOCITY
 from ..utils.topics import (
     GNSS_STATUS,
@@ -90,14 +90,7 @@ class Localization(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = Localization()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/localization/localization.py
+++ b/src/eel/eel/localization/localization.py
@@ -3,6 +3,7 @@ import time
 from typing import Optional
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
@@ -89,8 +90,14 @@ class Localization(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = Localization()
-    rclpy.spin(node)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/modem/modem_node.py
+++ b/src/eel/eel/modem/modem_node.py
@@ -2,12 +2,12 @@
 from typing import Optional
 
 import rclpy
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import ModemStatus
 
 from ..utils.constants import SIMULATE_PARAM
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import MODEM_STATUS
 from .modem_source import ModemSource
 
@@ -64,14 +64,7 @@ class ModemNode(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = ModemNode()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/modem/modem_node.py
+++ b/src/eel/eel/modem/modem_node.py
@@ -2,6 +2,7 @@
 from typing import Optional
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import ModemStatus
@@ -63,8 +64,14 @@ class ModemNode(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = ModemNode()
-    rclpy.spin(node)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/motor/motor_node.py
+++ b/src/eel/eel/motor/motor_node.py
@@ -2,6 +2,7 @@
 from typing import Callable, Optional
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
@@ -54,8 +55,15 @@ class Motor(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = Motor()
-    rclpy.spin(node)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.stop()
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/motor/motor_node.py
+++ b/src/eel/eel/motor/motor_node.py
@@ -2,11 +2,11 @@
 from typing import Callable, Optional
 
 import rclpy
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
 from ..utils.constants import SIMULATE_PARAM
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import MOTOR_CMD
 from ..utils.utils import clamp
 from .motor_sim import MotorSimulator
@@ -55,15 +55,7 @@ class Motor(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = Motor()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.stop()
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node, cleanup=node.stop)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/mqtt_bridge/node.py
+++ b/src/eel/eel/mqtt_bridge/node.py
@@ -5,7 +5,6 @@ from typing import Callable, List, Mapping, Optional, Sequence, Tuple, TypedDict
 import rclpy
 from awscrt import mqtt
 from awsiot import mqtt_connection_builder
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Bool, Float32, String
 
@@ -24,6 +23,7 @@ from eel_interfaces.msg import (
     TracedRoute,
 )
 
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.throttle import throttle
 from ..utils.topics import (
     BATTERY_STATUS,
@@ -558,14 +558,7 @@ class MqttBridge(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = MqttBridge()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/mqtt_bridge/node.py
+++ b/src/eel/eel/mqtt_bridge/node.py
@@ -5,6 +5,7 @@ from typing import Callable, List, Mapping, Optional, Sequence, Tuple, TypedDict
 import rclpy
 from awscrt import mqtt
 from awsiot import mqtt_connection_builder
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Bool, Float32, String
 
@@ -557,8 +558,14 @@ class MqttBridge(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = MqttBridge()
-    rclpy.spin(node)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/navigation/navigation_action_client.py
+++ b/src/eel/eel/navigation/navigation_action_client.py
@@ -8,7 +8,6 @@ import rclpy
 from action_msgs.msg import GoalStatus
 from rclpy.action import ActionClient
 from rclpy.action.client import ClientGoalHandle
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rclpy.task import Future
 from std_msgs.msg import Bool, String
@@ -24,6 +23,7 @@ from eel_interfaces.msg import (
 )
 
 from ..utils.constants import NavigationMissionStatus
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import (
     BATTERY_STATUS,
     GNSS_STATUS,
@@ -441,14 +441,7 @@ class NavigationActionClient(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     action_client = NavigationActionClient()
-
-    try:
-        rclpy.spin(action_client)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        action_client.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(action_client)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/navigation/navigation_action_client.py
+++ b/src/eel/eel/navigation/navigation_action_client.py
@@ -8,6 +8,7 @@ import rclpy
 from action_msgs.msg import GoalStatus
 from rclpy.action import ActionClient
 from rclpy.action.client import ClientGoalHandle
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rclpy.task import Future
 from std_msgs.msg import Bool, String
@@ -440,8 +441,14 @@ class NavigationActionClient(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     action_client = NavigationActionClient()
-    rclpy.spin(action_client)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(action_client)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        action_client.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/navigation/navigation_action_server.py
+++ b/src/eel/eel/navigation/navigation_action_server.py
@@ -8,13 +8,14 @@ import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from rclpy.action.server import ServerGoalHandle
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.executors import ExternalShutdownException, MultiThreadedExecutor
+from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
 from eel_interfaces.action import Navigate
 from eel_interfaces.msg import Coordinate, DepthControlCmd, ImuStatus, PressureStatus
 
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import (
     DEPTH_CONTROL_CMD,
     IMU_STATUS,
@@ -231,14 +232,7 @@ def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     navigation_action_server = NavigationActionServer()
     executor = MultiThreadedExecutor()
-
-    try:
-        rclpy.spin(navigation_action_server, executor=executor)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        navigation_action_server.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(navigation_action_server, executor=executor)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/navigation/navigation_action_server.py
+++ b/src/eel/eel/navigation/navigation_action_server.py
@@ -8,7 +8,7 @@ import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from rclpy.action.server import ServerGoalHandle
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.executors import MultiThreadedExecutor
+from rclpy.executors import ExternalShutdownException, MultiThreadedExecutor
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
@@ -229,12 +229,16 @@ class NavigationActionServer(Node):
 
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
-
     navigation_action_server = NavigationActionServer()
     executor = MultiThreadedExecutor()
-    rclpy.spin(navigation_action_server, executor=executor)
 
-    rclpy.shutdown()
+    try:
+        rclpy.spin(navigation_action_server, executor=executor)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        navigation_action_server.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/pressure/pressure_node.py
+++ b/src/eel/eel/pressure/pressure_node.py
@@ -4,12 +4,12 @@ from time import time
 from typing import Optional
 
 import rclpy
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import ImuStatus, PressureStatus
 
 from ..utils.constants import SIMULATE_PARAM
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import IMU_STATUS, PRESSURE_STATUS
 from .pressure_source import PressureSource
 
@@ -98,14 +98,7 @@ class PressureNode(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = PressureNode()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/pressure/pressure_node.py
+++ b/src/eel/eel/pressure/pressure_node.py
@@ -4,6 +4,7 @@ from time import time
 from typing import Optional
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from eel_interfaces.msg import ImuStatus, PressureStatus
@@ -97,8 +98,14 @@ class PressureNode(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = PressureNode()
-    rclpy.spin(node)
-    rclpy.shutdown()
+
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/rudder/rudder_node.py
+++ b/src/eel/eel/rudder/rudder_node.py
@@ -78,7 +78,6 @@ class Rudder(Node):
         self.publish_rudder_offset_value(Rudders.RUDDER_Y)
 
     def shutdown(self) -> None:
-        self.logger.info("Rudder node shutting down...")
         self.xy_rudder.shutdown()
 
     def _handle_imu_msg(self, msg: ImuStatus) -> None:

--- a/src/eel/eel/rudder/rudder_node.py
+++ b/src/eel/eel/rudder/rudder_node.py
@@ -5,13 +5,13 @@ from typing import Optional
 
 import rclpy
 from geometry_msgs.msg import Vector3
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
 from eel_interfaces.msg import ImuStatus
 
 from ..utils.constants import SIMULATE_PARAM
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import (
     IMU_STATUS,
     RUDDER_STATUS,
@@ -164,15 +164,7 @@ class Rudder(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = Rudder()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.shutdown()
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node, cleanup=node.shutdown)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/rudder/rudder_node.py
+++ b/src/eel/eel/rudder/rudder_node.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 import math
-import signal
-import sys
 from enum import Enum
-from types import FrameType
 from typing import Optional
 
 import rclpy
 from geometry_msgs.msg import Vector3
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
@@ -164,30 +162,17 @@ class Rudder(Node):
         self.rudder_status_publisher.publish(status_vector_msg)
 
 
-def shutdown_handler(signum: int, frame: FrameType | None, node: Rudder) -> None:
-    # Call the shutdown method of your node
-    node.shutdown()
-    rclpy.try_shutdown()
-    sys.exit(0)
-
-
-# Register the shutdown handler for SIGTERM signal
-
-
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = Rudder()
-    signal.signal(signal.SIGTERM, lambda signum, frame: shutdown_handler(signum, frame, node))
 
     try:
         rclpy.spin(node)
-    except KeyboardInterrupt:
-        # pass
-        sys.exit(1)
-    # except ExternalShutdownException:
-    #     sys.exit(1)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
     finally:
         node.shutdown()
+        node.destroy_node()
         rclpy.try_shutdown()
 
 

--- a/src/eel/eel/tank/tank_node.py
+++ b/src/eel/eel/tank/tank_node.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import math
-import sys
 from typing import Literal, Optional
 
 import rclpy
@@ -307,12 +306,11 @@ def main(args: Optional[list[str]] = None) -> None:
 
     try:
         rclpy.spin(node)
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    except ExternalShutdownException:
-        sys.exit(1)
     finally:
         node.shutdown()
+        node.destroy_node()
         rclpy.try_shutdown()
 
 

--- a/src/eel/eel/tank/tank_node.py
+++ b/src/eel/eel/tank/tank_node.py
@@ -3,7 +3,6 @@ import math
 from typing import Literal, Optional
 
 import rclpy
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
@@ -19,6 +18,7 @@ from ..utils.constants import (
     TANK_CEILING_VALUE_PARAM,
     TANK_FLOOR_VALUE_PARAM,
 )
+from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.pid_controller import PidController
 from ..utils.utils import clamp
 from .tank_utils.create_tank import create_tank
@@ -302,15 +302,7 @@ class TankNode(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = TankNode()
-
-    try:
-        rclpy.spin(node)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        node.shutdown()
-        node.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(node, cleanup=node.shutdown)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/tank/tank_node.py
+++ b/src/eel/eel/tank/tank_node.py
@@ -295,7 +295,6 @@ class TankNode(Node):
             self.tank.run_motor(next_value)
 
     def shutdown(self) -> None:
-        self.get_logger().info("Shutting down")
         self.stop_checking_against_target()
         self.tank.shutdown()
 

--- a/src/eel/eel/utils/node_runner.py
+++ b/src/eel/eel/utils/node_runner.py
@@ -17,6 +17,9 @@ def spin_node_until_shutdown(
         pass
     finally:
         if cleanup is not None:
-            cleanup()
+            try:
+                cleanup()
+            except Exception:
+                pass
         node.destroy_node()
         rclpy.try_shutdown()

--- a/src/eel/eel/utils/node_runner.py
+++ b/src/eel/eel/utils/node_runner.py
@@ -1,0 +1,22 @@
+from collections.abc import Callable
+
+import rclpy
+from rclpy.executors import ExternalShutdownException, MultiThreadedExecutor
+from rclpy.node import Node
+
+
+def spin_node_until_shutdown(
+    node: Node,
+    *,
+    executor: MultiThreadedExecutor | None = None,
+    cleanup: Callable[[], None] | None = None,
+) -> None:
+    try:
+        rclpy.spin(node, executor=executor)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        if cleanup is not None:
+            cleanup()
+        node.destroy_node()
+        rclpy.try_shutdown()

--- a/src/eel/setup.py
+++ b/src/eel/setup.py
@@ -46,7 +46,6 @@ setup(
     entry_points={
         "console_scripts": [
             "dive = eel.dive.dive_action_server:main",
-            "dive_client = eel.dive.dive_action_client:main",
             "navigate = eel.navigation.navigation_action_server:main",
             "navigate_client = eel.navigation.navigation_action_client:main",
             "gnss = eel.gnss.gnss_node:main",

--- a/src/eel/test/eel/integration/dive_demo.py
+++ b/src/eel/test/eel/integration/dive_demo.py
@@ -1,3 +1,5 @@
+"""Integration boot-test fixture: one-shot dive action client."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Protocol, TypeAlias
@@ -5,6 +7,7 @@ from typing import TYPE_CHECKING, Optional, Protocol, TypeAlias
 import rclpy
 from rclpy.action import ActionClient
 from rclpy.action.client import ClientGoalHandle
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rclpy.task import Future
 
@@ -26,11 +29,10 @@ class DiveFeedbackMessage(Protocol):
     feedback: Dive.Feedback
 
 
-class DiveActionClient(Node):
+class DiveDemo(Node):
     def __init__(self) -> None:
-        super().__init__("dive_action_client")
+        super().__init__("dive_demo")
         self._action_client = ActionClient(self, Dive, "dive")
-
         self.logger = self.get_logger()
 
     def send_goal(self, wanted_depth: float) -> None:
@@ -68,11 +70,16 @@ class DiveActionClient(Node):
 
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
+    demo = DiveDemo()
+    demo.send_goal(2.0)
 
-    action_client = DiveActionClient()
-    action_client.send_goal(2.0)
-
-    rclpy.spin(action_client)
+    try:
+        rclpy.spin(demo)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        demo.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/eel/test/eel/integration/dive_demo.py
+++ b/src/eel/test/eel/integration/dive_demo.py
@@ -61,7 +61,7 @@ class DiveDemo(Node):
         result_response = future.result()
         result = result_response.result
         self.logger.info(f"Result, final depth: {result.final_depth}m")
-        rclpy.shutdown()
+        rclpy.try_shutdown()
 
     def feedback_callback(self, feedback_msg: DiveFeedbackMessage) -> None:
         feedback = feedback_msg.feedback

--- a/src/eel/test/eel/integration/dive_demo.py
+++ b/src/eel/test/eel/integration/dive_demo.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Protocol, TypeAlias
 
 import rclpy
+from eel.utils.node_runner import spin_node_until_shutdown
 from rclpy.action import ActionClient
 from rclpy.action.client import ClientGoalHandle
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rclpy.task import Future
 
@@ -72,14 +72,7 @@ def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     demo = DiveDemo()
     demo.send_goal(2.0)
-
-    try:
-        rclpy.spin(demo)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-    finally:
-        demo.destroy_node()
-        rclpy.try_shutdown()
+    spin_node_until_shutdown(demo)
 
 
 if __name__ == "__main__":

--- a/src/eel/test/eel/integration/integration_all_sim_nodes_startup.launch.py
+++ b/src/eel/test/eel/integration/integration_all_sim_nodes_startup.launch.py
@@ -1,3 +1,8 @@
+"""Integration boot test only — co-located with test_all_sim_nodes_publish_status_on_startup.py."""
+
+import os
+import sys
+
 from eel.utils.constants import (
     CMD_TOPIC_PARAM,
     DIRECTION_PIN_PARAM,
@@ -14,9 +19,11 @@ from eel.utils.topics import (
     REAR_TANK_CMD,
     REAR_TANK_STATUS,
 )
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
 from launch_ros.actions import Node
 
-from launch import LaunchDescription
+_INTEGRATION_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def _tank_node(
@@ -51,22 +58,28 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            # Asserted via status topics in test_all_sim_nodes_publish_status_on_startup.py
             Node(package="eel", executable="imu", name="imu_node", parameters=[simulate]),
-            Node(package="eel", executable="motor", name="motor_node", parameters=[simulate]),
-            Node(package="eel", executable="rudder", name="rudder_node", parameters=[simulate]),
             Node(package="eel", executable="battery", name="battery_node", parameters=[simulate]),
             Node(package="eel", executable="pressure", name="pressure_node", parameters=[simulate]),
             _tank_node("front_tank", FRONT_TANK_CMD, FRONT_TANK_STATUS, 23, 18, 0, 0.66, 0.16),
             _tank_node("rear_tank", REAR_TANK_CMD, REAR_TANK_STATUS, 24, 25, 1, 0.325, 0.005),
             Node(package="eel", executable="leakage", name="leakage_node", parameters=[simulate]),
             Node(package="eel", executable="modem", name="modem_node", parameters=[simulate]),
-            Node(package="eel", executable="localization", name="localization"),
-            Node(package="eel", executable="navigate", name="navigation_action_server"),
+            Node(package="eel", executable="rudder", name="rudder_node", parameters=[simulate]),
             Node(package="eel", executable="navigate_client", name="navigation_action_client"),
             Node(package="eel", executable="depth_control_rudder", name="depth_control_rudder_node"),
+            # Boot-only: started to catch import/crash regressions, not status-asserted
+            Node(package="eel", executable="motor", name="motor_node", parameters=[simulate]),
+            Node(package="eel", executable="localization", name="localization"),
+            Node(package="eel", executable="navigate", name="navigation_action_server"),
             Node(package="eel", executable="depth_control", name="depth_control_tank_node"),
             Node(package="eel", executable="dive", name="dive_action_server"),
-            Node(package="eel", executable="dive_client", name="dive_action_client"),
+            ExecuteProcess(
+                cmd=[sys.executable, os.path.join(_INTEGRATION_DIR, "dive_demo.py")],
+                name="dive_demo",
+                output="screen",
+            ),
             Node(package="eel", executable="data_logger", name="data_logger_node"),
         ]
     )

--- a/src/eel/test/eel/integration/test_all_sim_nodes_publish_status_on_startup.py
+++ b/src/eel/test/eel/integration/test_all_sim_nodes_publish_status_on_startup.py
@@ -3,7 +3,6 @@ import unittest
 
 import launch
 import pytest
-from ament_index_python.packages import get_package_share_directory
 from eel.utils.topics import (
     BATTERY_STATUS,
     DEPTH_CONTROL_STATUS,
@@ -61,9 +60,8 @@ def _assert_no_process_crashed(proc_info) -> None:
 @pytest.mark.launch_test
 def generate_test_description():
     launch_file = os.path.join(
-        get_package_share_directory("eel_bringup"),
-        "launch",
-        "sim_all_nodes_startup.launch.py",
+        os.path.dirname(__file__),
+        "integration_all_sim_nodes_startup.launch.py",
     )
     return (
         launch.LaunchDescription(


### PR DESCRIPTION
## Summary
- Apply the upstream Jazzy shutdown pattern to all Python node entry points so Ctrl+C and launch teardown exit without KeyboardInterrupt tracebacks
- Stop actuators on hardware nodes (motor, tank, rudder) before teardown; remove rudder's redundant SIGTERM handler
- Co-locate integration boot-test launch and dive fixture with the integration test; drop `dive_client` from production entry points

Closes #131

## Test plan
- [x] `make test` (unit checks + integration boot test)
- [ ] Manual Ctrl+C on a sim node, e.g. `ros2 run eel imu --ros-args -p simulate:=true`