### PR TITLE
fix: complete off-Pi sim coverage for all hardware nodes

### DIFF
--- a/src/eel/eel/gnss/gnss_node.py
+++ b/src/eel/eel/gnss/gnss_node.py
@@ -9,7 +9,7 @@ from eel_interfaces.msg import Coordinate
 from ..utils.constants import SIMULATE_PARAM
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import GNSS_STATUS
-from .gnss_sensor import GnssSensor
+from .gnss_sim import GnssSimulator, GnssSource
 
 
 class GNSS(Node):
@@ -23,17 +23,22 @@ class GNSS(Node):
 
         self.publisher = self.create_publisher(Coordinate, GNSS_STATUS, 10)
         self.declare_parameter(SIMULATE_PARAM, False)
+        should_simulate = bool(self.get_parameter(SIMULATE_PARAM).value)
 
-        # At the time of writing, Ålen uses /dev/ttyUSB1 (which is why it's the default)
-        # and Tvålen uses /dev/ttyUSB0 for some reason.
-        self.declare_parameter("serial_port", "/dev/ttyUSB1")
-        serial_port = self.get_parameter("serial_port").get_parameter_value().string_value
+        source: GnssSource
+        if should_simulate:
+            source = GnssSimulator()
+        else:
+            from .gnss_sensor import GnssSensor
 
-        sensor = GnssSensor(serial_port=serial_port)
-        self.get_current_position = sensor.get_current_position
+            self.declare_parameter("serial_port", "/dev/ttyUSB1")
+            serial_port = self.get_parameter("serial_port").get_parameter_value().string_value
+            source = GnssSensor(serial_port=serial_port)
+
+        self.get_current_position = source.get_current_position
 
         self.poller = self.create_timer(1.0 / self.update_frequency_hz, self.publish)
-        self.get_logger().info("GNSS node started.")
+        self.get_logger().info(f"{'SIMULATE ' if should_simulate else ''}GNSS node started.")
 
     def publish(self) -> None:
         lat, lon = self.get_current_position()

--- a/src/eel/eel/gnss/gnss_sim.py
+++ b/src/eel/eel/gnss/gnss_sim.py
@@ -1,0 +1,15 @@
+from typing import Protocol
+
+# Fixed simulated position near test/mission coordinates (Gröndal area).
+SIM_LAT = 59.309395
+SIM_LON = 17.974279
+
+
+class GnssSource(Protocol):
+    def get_current_position(self) -> tuple[float | None, float | None]:
+        pass
+
+
+class GnssSimulator:
+    def get_current_position(self) -> tuple[float | None, float | None]:
+        return SIM_LAT, SIM_LON

--- a/src/eel/eel/led_control/led_node.py
+++ b/src/eel/eel/led_control/led_node.py
@@ -6,10 +6,10 @@ from rclpy.node import Node
 
 from eel_interfaces.msg import NavigationStatus
 
-from ..utils.constants import NavigationMissionStatus
+from ..utils.constants import SIMULATE_PARAM, NavigationMissionStatus
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import NAVIGATION_STATUS
-from .led_control import LEDControl
+from .led_sim import LEDBackend, LEDSimulator
 
 PULSE_COUNT_MAP = {
     NavigationMissionStatus.WAITING_FOR_MISSION.value: 2,
@@ -31,8 +31,15 @@ PULSE_TIME_MAP = {
 class LED(Node):
     def __init__(self) -> None:
         super().__init__("LED_node")
+        self.declare_parameter(SIMULATE_PARAM, False)
+        self.should_simulate = bool(self.get_parameter(SIMULATE_PARAM).value)
 
-        self.led_control = LEDControl()
+        if self.should_simulate:
+            self.led_control: LEDBackend = LEDSimulator()
+        else:
+            from .led_control import LEDControl
+
+            self.led_control = LEDControl()
 
         self.navigation_status_subscription = self.create_subscription(
             NavigationStatus, NAVIGATION_STATUS, self.update_mission_status, 10
@@ -41,7 +48,7 @@ class LED(Node):
         self.poller = self.create_timer(3.0, self.pulse_led)
         self.navigation_status = NavigationMissionStatus.WAITING_FOR_MISSION.value
 
-        self.get_logger().info("Started LED node")
+        self.get_logger().info(f"{'SIMULATE ' if self.should_simulate else ''}LED node started.")
 
     def update_mission_status(self, msg: NavigationStatus) -> None:
         self.navigation_status = msg.mission_status

--- a/src/eel/eel/led_control/led_sim.py
+++ b/src/eel/eel/led_control/led_sim.py
@@ -1,0 +1,23 @@
+from typing import Protocol
+
+
+class LEDBackend(Protocol):
+    def sequence(self, nof_pulses: int = 3, pulse_time: float = 0.1) -> None:
+        pass
+
+    def on(self) -> None:
+        pass
+
+    def off(self) -> None:
+        pass
+
+
+class LEDSimulator:
+    def sequence(self, nof_pulses: int = 3, pulse_time: float = 0.1) -> None:
+        pass
+
+    def on(self) -> None:
+        pass
+
+    def off(self) -> None:
+        pass

--- a/src/eel/eel/motor/motor_control.py
+++ b/src/eel/eel/motor/motor_control.py
@@ -4,17 +4,15 @@ PWM_FREQUENCY = 1000
 DEFAULT_PWM_PIN = 12
 DEFAULT_DIR_PIN = 20
 
-FORWARD_LEVEL = GPIO.LOW
-BACKWARD_LEVEL = GPIO.HIGH
-GPIO.setmode(GPIO.BCM)
-GPIO.setwarnings(False)
-GPIO.setup(DEFAULT_DIR_PIN, GPIO.OUT)
-GPIO.setup(DEFAULT_PWM_PIN, GPIO.OUT)
-pwm_output = GPIO.PWM(DEFAULT_PWM_PIN, PWM_FREQUENCY)
-
 
 class MotorControl:
     def __init__(self) -> None:
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setwarnings(False)
+        GPIO.setup(DEFAULT_DIR_PIN, GPIO.OUT)
+        GPIO.setup(DEFAULT_PWM_PIN, GPIO.OUT)
+        self._pwm = GPIO.PWM(DEFAULT_PWM_PIN, PWM_FREQUENCY)
+
         # Power supply is providing 15 voltage, the motor that we are using can only handle 12 V.
         # Therefore we need to cap the pwm output signal in order to not damage the motor.
         self.input_voltage = 15
@@ -23,12 +21,16 @@ class MotorControl:
         self.motor_ctl_level = (self.motor_max_voltage / self.input_voltage) * self.pwm_max
 
     def forward(self, signal: float) -> None:
-        GPIO.output(DEFAULT_DIR_PIN, FORWARD_LEVEL)
-        pwm_output.start(signal * self.motor_ctl_level)
+        GPIO.output(DEFAULT_DIR_PIN, GPIO.LOW)
+        self._pwm.start(signal * self.motor_ctl_level)
 
     def backward(self, signal: float) -> None:
-        GPIO.output(DEFAULT_DIR_PIN, BACKWARD_LEVEL)
-        pwm_output.start(signal * self.motor_ctl_level)
+        GPIO.output(DEFAULT_DIR_PIN, GPIO.HIGH)
+        self._pwm.start(signal * self.motor_ctl_level)
 
     def stop(self) -> None:
-        pwm_output.stop()
+        self._pwm.stop()
+
+    def close(self) -> None:
+        self.stop()
+        GPIO.cleanup((DEFAULT_DIR_PIN, DEFAULT_PWM_PIN))

--- a/src/eel/eel/motor/motor_node.py
+++ b/src/eel/eel/motor/motor_node.py
@@ -23,6 +23,7 @@ class Motor(Node):
         stop: Callable[[], None]
         forward: Callable[[float], None]
         backward: Callable[[float], None]
+        self._motor_control = None
         if self.should_simulate:
             simulator = MotorSimulator()
             stop = simulator.stop
@@ -31,16 +32,21 @@ class Motor(Node):
         else:
             from .motor_control import MotorControl
 
-            motor_control = MotorControl()
-            stop = motor_control.stop
-            forward = motor_control.forward
-            backward = motor_control.backward
+            self._motor_control = MotorControl()
+            stop = self._motor_control.stop
+            forward = self._motor_control.forward
+            backward = self._motor_control.backward
 
         self.stop = stop
         self.forward = forward
         self.backward = backward
 
         self.get_logger().info("{}Motor node started.".format("SIMULATE " if self.should_simulate else ""))
+
+    def shutdown(self) -> None:
+        self.stop()
+        if self._motor_control is not None:
+            self._motor_control.close()
 
     def handle_motor_msg(self, msg: Float32) -> None:
         motor_value = clamp(msg.data, -1, 1)
@@ -55,7 +61,7 @@ class Motor(Node):
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = Motor()
-    spin_node_until_shutdown(node, cleanup=node.stop)
+    spin_node_until_shutdown(node, cleanup=node.shutdown)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/mqtt_bridge/mqtt_aws.py
+++ b/src/eel/eel/mqtt_bridge/mqtt_aws.py
@@ -1,0 +1,56 @@
+import json
+from typing import Mapping, TypedDict
+
+from awscrt import mqtt
+from awsiot import mqtt_connection_builder
+from rclpy.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class CertData(TypedDict):
+    endpoint: str
+    port: int
+    certificatePath: str
+    privateKeyPath: str
+    rootCAPath: str
+    clientID: str
+
+
+class AwsIotMqttBackend:
+    def __init__(self, cert_data: CertData) -> None:
+        self.robot_name = cert_data["clientID"]
+        self._cert_data = cert_data
+        self._conn: mqtt.Connection | None = None
+
+    def connect(self) -> None:
+        cert_data = self._cert_data
+        logger.info(f"Connecting directly to endpoint {cert_data['endpoint']}")
+        self._conn = mqtt_connection_builder.mtls_from_path(
+            endpoint=cert_data["endpoint"],
+            port=cert_data["port"],
+            cert_filepath=cert_data["certificatePath"],
+            pri_key_filepath=cert_data["privateKeyPath"],
+            ca_filepath=cert_data["rootCAPath"],
+            client_id=cert_data["clientID"],
+            http_proxy_options=None,
+        )
+        connected_future = self._conn.connect()
+        connected_future.result()
+        logger.info("Connected!")
+
+    def publish(self, topic: str, message: Mapping[str, object]) -> None:
+        if self._conn is None:
+            return
+        json_payload = json.dumps(message)
+        self._conn.publish(topic=topic, payload=json_payload, qos=mqtt.QoS.AT_LEAST_ONCE)
+
+    def subscribe(self, topic: str, callback: object) -> None:
+        if self._conn is None:
+            return
+        self._conn.subscribe(
+            topic=topic,
+            qos=mqtt.QoS.AT_LEAST_ONCE,
+            callback=callback,
+        )
+        logger.info(f"Subscribed to MQTT topic {topic}")

--- a/src/eel/eel/mqtt_bridge/mqtt_sim.py
+++ b/src/eel/eel/mqtt_bridge/mqtt_sim.py
@@ -1,0 +1,40 @@
+import json
+from typing import Mapping, Protocol
+
+SIM_ROBOT_NAME = "sim_robot"
+
+
+class MqttBackend(Protocol):
+    robot_name: str
+
+    def connect(self) -> None:
+        pass
+
+    def publish(self, topic: str, message: Mapping[str, object]) -> None:
+        pass
+
+    def subscribe(self, topic: str, callback: object) -> None:
+        pass
+
+
+class _Logger(Protocol):
+    def info(self, msg: str) -> None:
+        pass
+
+    def debug(self, msg: str) -> None:
+        pass
+
+
+class LoggingMqttBackend:
+    def __init__(self, logger: _Logger, robot_name: str = SIM_ROBOT_NAME) -> None:
+        self.robot_name = robot_name
+        self._logger = logger
+
+    def connect(self) -> None:
+        self._logger.info(f"SIMULATE MQTT backend ready for {self.robot_name}")
+
+    def publish(self, topic: str, message: Mapping[str, object]) -> None:
+        self._logger.debug(f"SIMULATE MQTT publish {topic}: {json.dumps(message)}")
+
+    def subscribe(self, topic: str, callback: object) -> None:
+        self._logger.debug(f"SIMULATE MQTT subscribe {topic}")

--- a/src/eel/eel/mqtt_bridge/node.py
+++ b/src/eel/eel/mqtt_bridge/node.py
@@ -3,8 +3,6 @@ import json
 from typing import Callable, List, Mapping, Optional, Sequence, Tuple, TypedDict, cast
 
 import rclpy
-from awscrt import mqtt
-from awsiot import mqtt_connection_builder
 from rclpy.node import Node
 from std_msgs.msg import Bool, Float32, String
 
@@ -23,6 +21,7 @@ from eel_interfaces.msg import (
     TracedRoute,
 )
 
+from ..utils.constants import SIMULATE_PARAM
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.throttle import throttle
 from ..utils.topics import (
@@ -48,16 +47,8 @@ from ..utils.topics import (
     RUDDER_X_CMD,
     RUDDER_Y_CMD,
 )
+from .mqtt_sim import LoggingMqttBackend, MqttBackend
 from .types import CoordinateMqtt, to_traced_route_mqtt, transform_coordinate_msg
-
-
-class CertData(TypedDict):
-    endpoint: str
-    port: int
-    certificatePath: str
-    privateKeyPath: str
-    rootCAPath: str
-    clientID: str
 
 
 class DepthControlCmdMqtt(TypedDict):
@@ -131,15 +122,7 @@ class PressureStatusMqtt(TypedDict):
     depth_velocity: float
 
 
-SubscriberCallback = Callable[[str, bytes, bool, mqtt.QoS, bool], None]
-
-
-def init_one_mqtt_sub(mqtt_conn: mqtt.Connection, topic: str, callback: SubscriberCallback) -> None:
-    mqtt_conn.subscribe(
-        topic=topic,
-        qos=mqtt.QoS.AT_LEAST_ONCE,
-        callback=callback,
-    )
+SubscriberCallback = Callable[[str, bytes, bool, object, bool], None]
 
 
 def transform_battery_msg(msg: BatteryStatus) -> BatteryStatusMqtt:
@@ -201,42 +184,33 @@ class MqttBridge(Node):
     def __init__(self) -> None:
         super().__init__("mqtt_bridge_node", parameter_overrides=[])
 
-        self.mqtt_conn: Optional[mqtt.Connection] = None
-
+        self.declare_parameter(SIMULATE_PARAM, False)
+        should_simulate = bool(self.get_parameter(SIMULATE_PARAM).value)
         self.declare_parameter("path_for_config", "")
-
-        path_for_config = self.get_parameter("path_for_config").get_parameter_value().string_value
 
         self.is_connected: bool = False
 
-        self.get_logger().info("MQTT bridge node starting...")
+        mqtt_backend: MqttBackend
+        if should_simulate:
+            mqtt_backend = LoggingMqttBackend(logger=self.get_logger())
+        else:
+            from .mqtt_aws import AwsIotMqttBackend, CertData
 
-        with open(path_for_config) as f:
-            cert_data = json.load(f)
-            cert_data = cast(CertData, cert_data)
-            self.robot_name = cert_data["clientID"]
+            path_for_config = self.get_parameter("path_for_config").get_parameter_value().string_value
+            with open(path_for_config) as f:
+                cert_data = cast(CertData, json.load(f))
+            mqtt_backend = AwsIotMqttBackend(cert_data)
 
-        self.get_logger().info("Connecting directly to endpoint")
-        self.connect_to_endpoint(cert_data)
+        self._mqtt = mqtt_backend
+        self.robot_name = mqtt_backend.robot_name
+
+        prefix = "SIMULATE " if should_simulate else ""
+        self.get_logger().info(f"{prefix}MQTT bridge node starting...")
+        self._mqtt.connect()
 
         self.init_subs()
         self.init_ros_pubs()
         self.init_mqtt_subs()
-
-    def connect_to_endpoint(self, cert_data: CertData) -> None:
-        self.get_logger().info(f"Connecting directly to endpoint {cert_data['endpoint']}")
-        self.mqtt_conn = mqtt_connection_builder.mtls_from_path(
-            endpoint=cert_data["endpoint"],
-            port=cert_data["port"],
-            cert_filepath=cert_data["certificatePath"],
-            pri_key_filepath=cert_data["privateKeyPath"],
-            ca_filepath=cert_data["rootCAPath"],
-            client_id=cert_data["clientID"],
-            http_proxy_options=None,
-        )
-        connected_future = self.mqtt_conn.connect()
-        connected_future.result()
-        self.get_logger().info("Connected!")
 
     def init_mqtt_subs(self) -> None:
         topics_and_callbacks: Sequence[Tuple[str, SubscriberCallback]] = [
@@ -278,14 +252,8 @@ class MqttBridge(Node):
                 self.handle_incoming_gnss_status,
             ),
         ]
-        if self.mqtt_conn:
-            for t in topics_and_callbacks:
-                topic = t[0]
-                callback = t[1]
-                init_one_mqtt_sub(mqtt_conn=self.mqtt_conn, topic=topic, callback=callback)
-                self.get_logger().info(f"Subscribed to MQTT topic {topic}")
-        else:
-            self.get_logger().info("Could not subscribe. Connection is undefined.")
+        for topic, callback in topics_and_callbacks:
+            self._mqtt.subscribe(topic, callback)
 
     def init_ros_pubs(self) -> None:
         self.motor_publisher = self.create_publisher(Float32, MOTOR_CMD, 10)
@@ -335,7 +303,7 @@ class MqttBridge(Node):
         topic: str,
         payload: bytes,
         dup: bool,
-        qos: mqtt.QoS,
+        qos: object,
         retain: bool,
         **_kwargs: object,
     ) -> None:
@@ -349,7 +317,7 @@ class MqttBridge(Node):
         topic: str,
         payload: bytes,
         dup: bool,
-        qos: mqtt.QoS,
+        qos: object,
         retain: bool,
         **_kwargs: object,
     ) -> None:
@@ -363,7 +331,7 @@ class MqttBridge(Node):
         topic: str,
         payload: bytes,
         dup: bool,
-        qos: mqtt.QoS,
+        qos: object,
         retain: bool,
         **_kwargs: object,
     ) -> None:
@@ -378,7 +346,7 @@ class MqttBridge(Node):
         topic: str,
         payload: bytes,
         dup: bool,
-        qos: mqtt.QoS,
+        qos: object,
         retain: bool,
         **_kwargs: object,
     ) -> None:
@@ -392,7 +360,7 @@ class MqttBridge(Node):
         topic: str,
         payload: bytes,
         dup: bool,
-        qos: mqtt.QoS,
+        qos: object,
         retain: bool,
         **_kwargs: object,
     ) -> None:
@@ -409,7 +377,7 @@ class MqttBridge(Node):
         topic: str,
         payload: bytes,
         dup: bool,
-        qos: mqtt.QoS,
+        qos: object,
         retain: bool,
         **_kwargs: object,
     ) -> None:
@@ -424,7 +392,7 @@ class MqttBridge(Node):
         topic: str,
         payload: bytes,
         dup: bool,
-        qos: mqtt.QoS,
+        qos: object,
         retain: bool,
         **_kwargs: object,
     ) -> None:
@@ -439,7 +407,7 @@ class MqttBridge(Node):
         topic: str,
         payload: bytes,
         dup: bool,
-        qos: mqtt.QoS,
+        qos: object,
         retain: bool,
         **_kwargs: object,
     ) -> None:
@@ -463,7 +431,7 @@ class MqttBridge(Node):
         topic: str,
         payload: bytes,
         dup: bool,
-        qos: mqtt.QoS,
+        qos: object,
         retain: bool,
         **_kwargs: object,
     ) -> None:
@@ -477,7 +445,7 @@ class MqttBridge(Node):
         topic: str,
         payload: bytes,
         dup: bool,
-        qos: mqtt.QoS,
+        qos: object,
         retain: bool,
         **_kwargs: object,
     ) -> None:
@@ -488,9 +456,8 @@ class MqttBridge(Node):
         self.gnss_status_publisher.publish(msg)
 
     def publish_mqtt(self, topic: str, mqtt_message: Mapping[str, object]) -> None:
-        if self.is_connected is True and self.mqtt_conn:
-            json_payload = json.dumps(mqtt_message)
-            self.mqtt_conn.publish(topic=topic, payload=json_payload, qos=mqtt.QoS.AT_LEAST_ONCE)
+        if self.is_connected:
+            self._mqtt.publish(topic, mqtt_message)
 
     def modem_status_callback(self, msg: ModemStatus) -> None:
         self.is_connected = msg.connectivity

--- a/src/eel/test/eel/integration/integration_all_sim_nodes_startup.launch.py
+++ b/src/eel/test/eel/integration/integration_all_sim_nodes_startup.launch.py
@@ -71,6 +71,7 @@ def generate_launch_description():
             Node(package="eel", executable="depth_control_rudder", name="depth_control_rudder_node"),
             # Boot-only: started to catch import/crash regressions, not status-asserted
             Node(package="eel", executable="motor", name="motor_node", parameters=[simulate]),
+            Node(package="eel", executable="led_control", name="led_node", parameters=[simulate]),
             Node(package="eel", executable="localization", name="localization"),
             Node(package="eel", executable="navigate", name="navigation_action_server"),
             Node(package="eel", executable="depth_control", name="depth_control_tank_node"),

--- a/src/eel/test/eel/integration/integration_all_sim_nodes_startup.launch.py
+++ b/src/eel/test/eel/integration/integration_all_sim_nodes_startup.launch.py
@@ -62,6 +62,7 @@ def generate_launch_description():
             Node(package="eel", executable="imu", name="imu_node", parameters=[simulate]),
             Node(package="eel", executable="battery", name="battery_node", parameters=[simulate]),
             Node(package="eel", executable="pressure", name="pressure_node", parameters=[simulate]),
+            Node(package="eel", executable="gnss", name="gnss_node", parameters=[simulate]),
             _tank_node("front_tank", FRONT_TANK_CMD, FRONT_TANK_STATUS, 23, 18, 0, 0.66, 0.16),
             _tank_node("rear_tank", REAR_TANK_CMD, REAR_TANK_STATUS, 24, 25, 1, 0.325, 0.005),
             Node(package="eel", executable="leakage", name="leakage_node", parameters=[simulate]),

--- a/src/eel/test/eel/integration/integration_all_sim_nodes_startup.launch.py
+++ b/src/eel/test/eel/integration/integration_all_sim_nodes_startup.launch.py
@@ -73,6 +73,7 @@ def generate_launch_description():
             # Boot-only: started to catch import/crash regressions, not status-asserted
             Node(package="eel", executable="motor", name="motor_node", parameters=[simulate]),
             Node(package="eel", executable="led_control", name="led_node", parameters=[simulate]),
+            Node(package="eel", executable="mqtt_bridge", name="mqtt_bridge_node", parameters=[simulate]),
             Node(package="eel", executable="localization", name="localization"),
             Node(package="eel", executable="navigate", name="navigation_action_server"),
             Node(package="eel", executable="depth_control", name="depth_control_tank_node"),

--- a/src/eel/test/eel/integration/test_all_sim_nodes_publish_status_on_startup.py
+++ b/src/eel/test/eel/integration/test_all_sim_nodes_publish_status_on_startup.py
@@ -7,6 +7,7 @@ from eel.utils.topics import (
     BATTERY_STATUS,
     DEPTH_CONTROL_STATUS,
     FRONT_TANK_STATUS,
+    GNSS_STATUS,
     IMU_STATUS,
     LEAKAGE_STATUS,
     MODEM_STATUS,
@@ -25,6 +26,7 @@ from std_msgs.msg import Bool
 
 from eel_interfaces.msg import (
     BatteryStatus,
+    Coordinate,
     DepthControlStatus,
     ImuStatus,
     ModemStatus,
@@ -40,6 +42,7 @@ STATUS_PUBLISHERS: list[tuple[str, str, type]] = [
     ("imu_node", IMU_STATUS, ImuStatus),
     ("battery_node", BATTERY_STATUS, BatteryStatus),
     ("pressure_node", PRESSURE_STATUS, PressureStatus),
+    ("gnss_node", GNSS_STATUS, Coordinate),
     ("front_tank", FRONT_TANK_STATUS, TankStatus),
     ("rear_tank", REAR_TANK_STATUS, TankStatus),
     ("leakage_node", LEAKAGE_STATUS, Bool),


### PR DESCRIPTION
## Summary
- LED, GNSS, and motor get working sim/off-Pi paths; mqtt_bridge swaps in a logging backend under simulate
- Integration boot launch now includes every package entry point so regressions are caught locally and in Docker colcon test

Closes #177
Closes #178
Closes #179

## Test plan
- [x] `source source_me.sh && make build && make test`
- [ ] `ros2 run eel led_control --ros-args -p simulate:=true`
- [ ] `ros2 run eel gnss --ros-args -p simulate:=true`
- [ ] `ros2 run eel mqtt_bridge --ros-args -p simulate:=true`