### PR TITLE
fix: skip IMU publish when euler read is missing

### DIFF
--- a/src/eel/eel/imu/imu_node.py
+++ b/src/eel/eel/imu/imu_node.py
@@ -10,24 +10,9 @@ from eel_interfaces.msg import ImuOffsets, ImuStatus
 from ..utils.constants import SIMULATE_PARAM
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import IMU_OFFSETS, IMU_STATUS
-from .imu_sensor import ImuSensor
+from .imu_sensor import ImuSensor, update_pitch_velocity_state
 from .imu_sim import ImuSimulator
 from .types import CalibrationOffsets
-
-
-def get_pitch_velocity(
-    pitch: float,
-    previous_pitch: float | None,
-    now: float,
-    previous_pitch_at: float | None,
-) -> float:
-    if previous_pitch is None or previous_pitch_at is None:
-        return 0.0
-    pitch_delta = pitch - previous_pitch
-    time_delta = now - previous_pitch_at
-    velocity = pitch_delta / time_delta
-    return velocity
-
 
 SENSOR_CALIBRATION_OFFSETS: CalibrationOffsets | None = None
 # SENSOR_CALIBRATION_OFFSETS = {
@@ -80,7 +65,19 @@ class ImuNode(Node):
 
     def publish_imu(self) -> None:
         try:
-            heading, roll, pitch = self.get_euler()
+            euler = self.get_euler()
+            now = time()
+            pitch_velocity, previous_pitch, previous_pitch_at = update_pitch_velocity_state(
+                euler=euler,
+                now=now,
+                previous_pitch=self.previous_pitch,
+                previous_pitch_at=self.previous_pitch_at,
+            )
+            if euler is None:
+                self.previous_pitch = previous_pitch
+                self.previous_pitch_at = previous_pitch_at
+                return
+            heading, roll, pitch = euler
             sys, gyro, accel, mag = self.get_calibration_status()
             is_calibrated = self.get_is_calibrated()
 
@@ -93,19 +90,13 @@ class ImuNode(Node):
             msg.heading = heading
             msg.roll = roll
 
-            now = time()
-
-            pitch_to_send = pitch
-
-            pitch_velocity = get_pitch_velocity(pitch_to_send, self.previous_pitch, now, self.previous_pitch_at)
-
-            msg.pitch = pitch_to_send
-            msg.pitch_velocity = pitch_velocity
+            msg.pitch = pitch
+            msg.pitch_velocity = pitch_velocity or 0.0
 
             self.status_publisher.publish(msg)
 
-            self.previous_pitch = pitch_to_send
-            self.previous_pitch_at = now
+            self.previous_pitch = previous_pitch
+            self.previous_pitch_at = previous_pitch_at
 
         except (OSError, IOError) as err:
             self.get_logger().error(str(err))

--- a/src/eel/eel/imu/imu_sensor.py
+++ b/src/eel/eel/imu/imu_sensor.py
@@ -18,6 +18,48 @@ def get_corrected_heading(heading: float) -> float:
     return (heading - 180 + HEADING_CORRECTION) % 360
 
 
+def parse_euler_reading(
+    heading: float | None,
+    roll: float | None,
+    pitch: float | None,
+) -> tuple[float, float, float] | None:
+    if heading is None or roll is None or pitch is None:
+        return None
+    return (
+        get_corrected_heading(float(heading)),
+        get_corrected_roll(float(roll)),
+        get_corrected_pitch(-float(pitch)),
+    )
+
+
+def get_pitch_velocity(
+    pitch: float,
+    previous_pitch: float | None,
+    now: float,
+    previous_pitch_at: float | None,
+) -> float:
+    if previous_pitch is None or previous_pitch_at is None:
+        return 0.0
+    pitch_delta = pitch - previous_pitch
+    time_delta = now - previous_pitch_at
+    velocity = pitch_delta / time_delta
+    return velocity
+
+
+def update_pitch_velocity_state(
+    *,
+    euler: tuple[float, float, float] | None,
+    now: float,
+    previous_pitch: float | None,
+    previous_pitch_at: float | None,
+) -> tuple[float | None, float | None, float | None]:
+    if euler is None:
+        return None, None, None
+    pitch = euler[2]
+    velocity = get_pitch_velocity(pitch, previous_pitch, now, previous_pitch_at)
+    return velocity, pitch, now
+
+
 CALIBRATION_1 = {
     "mag": (193, 80, 84),
     "gyr": (-2, -7, 1),
@@ -76,13 +118,8 @@ class ImuSensor:
         sys, gyro, accel, mag = self.sensor.calibration_status
         return sys or 0, gyro or 0, accel or 0, mag or 0
 
-    def get_euler(self) -> tuple[float, float, float]:
-        heading, roll, pitch = self.sensor.euler
-        heading = float(heading or 0)
-        heading = get_corrected_heading(heading)
-        roll = get_corrected_roll(float(roll or 0))
-        pitch = get_corrected_pitch(-float(pitch or 0))
-        return heading, roll, pitch
+    def get_euler(self) -> tuple[float, float, float] | None:
+        return parse_euler_reading(*self.sensor.euler)
 
     def get_calibration_offsets(self) -> CalibrationOffsets:
         mag = self.sensor.offsets_magnetometer

--- a/src/eel/test/eel/imu/imu_sensor_test.py
+++ b/src/eel/test/eel/imu/imu_sensor_test.py
@@ -1,0 +1,49 @@
+from eel.imu.imu_sensor import parse_euler_reading, update_pitch_velocity_state
+
+
+def test__when_heading_is_none__should_return_none() -> None:
+    assert parse_euler_reading(None, 1.0, 2.0) is None
+
+
+def test__when_roll_is_none__should_return_none() -> None:
+    assert parse_euler_reading(90.0, None, 2.0) is None
+
+
+def test__when_pitch_is_none__should_return_none() -> None:
+    assert parse_euler_reading(90.0, 1.0, None) is None
+
+
+def test__when_valid_reading__should_apply_mount_correction() -> None:
+    result = parse_euler_reading(0.0, 0.0, 0.0)
+
+    assert result is not None
+    heading, roll, pitch = result
+    assert heading == 180.0
+    assert roll == 0.0
+    assert pitch == 1.69
+
+
+def test__when_euler_missing__should_clear_pitch_cache() -> None:
+    velocity, pitch, pitch_at = update_pitch_velocity_state(
+        euler=None,
+        now=100.0,
+        previous_pitch=1.0,
+        previous_pitch_at=99.0,
+    )
+
+    assert velocity is None
+    assert pitch is None
+    assert pitch_at is None
+
+
+def test__when_euler_returns_after_gap__should_have_zero_velocity() -> None:
+    velocity, pitch, pitch_at = update_pitch_velocity_state(
+        euler=(0.0, 0.0, 5.0),
+        now=100.0,
+        previous_pitch=None,
+        previous_pitch_at=None,
+    )
+
+    assert velocity == 0.0
+    assert pitch == 5.0
+    assert pitch_at == 100.0


### PR DESCRIPTION
## Summary

- Treat missing BNO055 euler components as absent instead of coercing them to zero
- Skip `ImuStatus` publish when the read is incomplete, avoiding a bogus 180° heading from mount correction
- Add unit tests for `parse_euler_reading`

Fixes #143

## Test plan

- [x] `make test-checks`
- [ ] `ros2 run eel imu --ros-args -p simulate:=true` still publishes normally in sim