### PR TITLE
fix: validate incoming dive goal time and depth

### DIFF
--- a/src/eel/eel/dive/dive_action_server.py
+++ b/src/eel/eel/dive/dive_action_server.py
@@ -17,6 +17,7 @@ from eel_interfaces.msg import ImuStatus, PressureStatus
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.pid_controller import PidController
 from ..utils.topics import IMU_STATUS, PRESSURE_STATUS, RUDDER_Y_CMD
+from .dive_goal_validation import is_dive_goal_valid
 
 UPDATE_FREQUENCY_PER_SEC = 5
 
@@ -108,11 +109,12 @@ class DiveActionServer(Node):
         return rudder_output
 
     def goal_callback(self, goal_request: Dive.Goal) -> GoalResponse:
-        # Sanity check for depth and dive that the values are not to large
-        depth_target_larger_then_max_depth = goal_request.wanted_depth > self.max_dive_depth_m
-        dive_time_larger_then_max_dive_time = self.dive_time > self.max_dive_time_sec
-
-        if any([depth_target_larger_then_max_depth, dive_time_larger_then_max_dive_time]):
+        if not is_dive_goal_valid(
+            wanted_depth=goal_request.wanted_depth,
+            dive_time=goal_request.dive_time,
+            max_depth_m=self.max_dive_depth_m,
+            max_dive_time_sec=self.max_dive_time_sec,
+        ):
             self.logger.info("Invalid request parameters, will reject goal.")
             return GoalResponse.REJECT
 

--- a/src/eel/eel/dive/dive_goal_validation.py
+++ b/src/eel/eel/dive/dive_goal_validation.py
@@ -1,3 +1,6 @@
+import math
+
+
 def is_dive_goal_valid(
     *,
     wanted_depth: float,
@@ -5,6 +8,10 @@ def is_dive_goal_valid(
     max_depth_m: float,
     max_dive_time_sec: float,
 ) -> bool:
+    if not math.isfinite(wanted_depth) or not math.isfinite(dive_time):
+        return False
+    if wanted_depth < 0 or dive_time <= 0:
+        return False
     if wanted_depth > max_depth_m:
         return False
     if dive_time > max_dive_time_sec:

--- a/src/eel/eel/dive/dive_goal_validation.py
+++ b/src/eel/eel/dive/dive_goal_validation.py
@@ -1,0 +1,12 @@
+def is_dive_goal_valid(
+    *,
+    wanted_depth: float,
+    dive_time: float,
+    max_depth_m: float,
+    max_dive_time_sec: float,
+) -> bool:
+    if wanted_depth > max_depth_m:
+        return False
+    if dive_time > max_dive_time_sec:
+        return False
+    return True

--- a/src/eel/test/eel/dive/dive_goal_validation_test.py
+++ b/src/eel/test/eel/dive/dive_goal_validation_test.py
@@ -29,3 +29,21 @@ def test__when_request_within_limits__should_accept() -> None:
         max_depth_m=MAX_DEPTH_M,
         max_dive_time_sec=MAX_DIVE_TIME_SEC,
     )
+
+
+def test__when_request_dive_time_is_negative__should_reject() -> None:
+    assert not is_dive_goal_valid(
+        wanted_depth=2.0,
+        dive_time=-1.0,
+        max_depth_m=MAX_DEPTH_M,
+        max_dive_time_sec=MAX_DIVE_TIME_SEC,
+    )
+
+
+def test__when_request_depth_is_nan__should_reject() -> None:
+    assert not is_dive_goal_valid(
+        wanted_depth=float("nan"),
+        dive_time=10.0,
+        max_depth_m=MAX_DEPTH_M,
+        max_dive_time_sec=MAX_DIVE_TIME_SEC,
+    )

--- a/src/eel/test/eel/dive/dive_goal_validation_test.py
+++ b/src/eel/test/eel/dive/dive_goal_validation_test.py
@@ -1,0 +1,31 @@
+from eel.dive.dive_goal_validation import is_dive_goal_valid
+
+MAX_DEPTH_M = 5.0
+MAX_DIVE_TIME_SEC = 120.0
+
+
+def test__when_request_dive_time_exceeds_max__should_reject() -> None:
+    assert not is_dive_goal_valid(
+        wanted_depth=2.0,
+        dive_time=121.0,
+        max_depth_m=MAX_DEPTH_M,
+        max_dive_time_sec=MAX_DIVE_TIME_SEC,
+    )
+
+
+def test__when_request_depth_exceeds_max__should_reject() -> None:
+    assert not is_dive_goal_valid(
+        wanted_depth=6.0,
+        dive_time=10.0,
+        max_depth_m=MAX_DEPTH_M,
+        max_dive_time_sec=MAX_DIVE_TIME_SEC,
+    )
+
+
+def test__when_request_within_limits__should_accept() -> None:
+    assert is_dive_goal_valid(
+        wanted_depth=2.0,
+        dive_time=10.0,
+        max_depth_m=MAX_DEPTH_M,
+        max_dive_time_sec=MAX_DIVE_TIME_SEC,
+    )

--- a/src/eel/test/eel/integration/dive_demo.py
+++ b/src/eel/test/eel/integration/dive_demo.py
@@ -35,9 +35,10 @@ class DiveDemo(Node):
         self._action_client = ActionClient(self, Dive, "dive")
         self.logger = self.get_logger()
 
-    def send_goal(self, wanted_depth: float) -> None:
+    def send_goal(self, wanted_depth: float, dive_time: float = 10.0) -> None:
         goal_msg = Dive.Goal()
         goal_msg.wanted_depth = wanted_depth
+        goal_msg.dive_time = dive_time
 
         self._action_client.wait_for_server()
 


### PR DESCRIPTION
## Summary

- Validate `goal_request.dive_time` and `wanted_depth` in dive `goal_callback` (was checking stale `self.dive_time`, so over-limit durations were never rejected)
- Extract `is_dive_goal_valid` for unit tests
- Set `dive_time` in the integration dive demo client

Fixes #145

## Test plan

- [x] `make test-checks`