### PR TITLE
fix: safety and node hygiene batch

### DIFF
--- a/src/eel/eel/dive/dive_action_server.py
+++ b/src/eel/eel/dive/dive_action_server.py
@@ -135,7 +135,6 @@ class DiveActionServer(Node):
         # Action server will do two things, first dive to a depth for X sec
         while time.time() - start_ts < self.dive_time:
             if goal_handle.is_cancel_requested:
-                goal_handle.canceled()
                 self.logger.info("Goal cancelled will start to ascend")
                 break
 
@@ -173,7 +172,10 @@ class DiveActionServer(Node):
                 goal_handle.publish_feedback(feedback_msg)
 
         self.send_rudder_msg(0.0)
-        goal_handle.succeed()
+        if goal_handle.is_cancel_requested:
+            goal_handle.canceled()
+        else:
+            goal_handle.succeed()
 
         result.final_depth = self.current_depth
         result.action_time = time.time() - start_ts

--- a/src/eel/eel/led_control/led_control.py
+++ b/src/eel/eel/led_control/led_control.py
@@ -25,6 +25,10 @@ class LEDControl:
     def off(self) -> None:
         GPIO.output(self.led_pin, LED_OFF_LEVEL)
 
+    def close(self) -> None:
+        self.off()
+        GPIO.cleanup((self.led_pin,))
+
 
 if __name__ == "__main__":
     led_controller = LEDControl()

--- a/src/eel/eel/led_control/led_node.py
+++ b/src/eel/eel/led_control/led_node.py
@@ -34,12 +34,14 @@ class LED(Node):
         self.declare_parameter(SIMULATE_PARAM, False)
         self.should_simulate = bool(self.get_parameter(SIMULATE_PARAM).value)
 
+        self._led_control = None
         if self.should_simulate:
             self.led_control: LEDBackend = LEDSimulator()
         else:
             from .led_control import LEDControl
 
-            self.led_control = LEDControl()
+            self._led_control = LEDControl()
+            self.led_control = self._led_control
 
         self.navigation_status_subscription = self.create_subscription(
             NavigationStatus, NAVIGATION_STATUS, self.update_mission_status, 10
@@ -60,11 +62,15 @@ class LED(Node):
         if nof_pulses is not None and pulse_length is not None:
             self.led_control.sequence(nof_pulses, pulse_length)
 
+    def shutdown(self) -> None:
+        if self._led_control is not None:
+            self._led_control.close()
+
 
 def main(args: Optional[list[str]] = None) -> None:
     rclpy.init(args=args)
     node = LED()
-    spin_node_until_shutdown(node)
+    spin_node_until_shutdown(node, cleanup=node.shutdown)
 
 
 if __name__ == "__main__":

--- a/src/eel/eel/modem/modem_node.py
+++ b/src/eel/eel/modem/modem_node.py
@@ -34,7 +34,7 @@ class ModemNode(Node):
 
         reg_status = self.sensor.get_registration_status()
         signal_strength = self.sensor.get_received_signal_strength_indicator()
-        if not reg_status or not signal_strength:
+        if reg_status is None or signal_strength is None:
             raise Exception("Could not start modem node. Not getting registration status and/or signal strength.")
 
         self.update_modem_timer = self.create_timer(2.0, self.read_and_publish_modem_status)

--- a/src/eel/eel/navigation/navigation_action_client.py
+++ b/src/eel/eel/navigation/navigation_action_client.py
@@ -27,7 +27,6 @@ from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import (
     BATTERY_STATUS,
     GNSS_STATUS,
-    LEAKAGE_STATUS,
     LOCALIZATION_STATUS,
     NAVIGATION_CMD,
     NAVIGATION_LOAD_MISSION,
@@ -229,8 +228,6 @@ class NavigationActionClient(Node):
             BatteryStatus, BATTERY_STATUS, self.handle_battery_status, 10
         )
 
-        self.leakage_status_subscriber = self.create_subscription(Bool, LEAKAGE_STATUS, self.handle_leakage_status, 10)
-
         self.pressure_status_subscriber = self.create_subscription(
             PressureStatus, PRESSURE_STATUS, self.handle_pressure_status, 10
         )
@@ -248,7 +245,6 @@ class NavigationActionClient(Node):
         self.updater = self.create_timer(1.0, self.publish_status)
 
         self.last_seen_battery_level = 100.0
-        self.last_seen_leakage = False
 
         self.current_position: Coordinate | None = None
 
@@ -323,16 +319,11 @@ class NavigationActionClient(Node):
         """Updates the last seen battery level variable."""
         self.last_seen_battery_level = msg.voltage_percent
 
-    def handle_leakage_status(self, msg: Bool) -> None:
-        self.last_seen_leakage = msg.data
-
     def handle_localization_update(self, msg: Coordinate) -> None:
         self.current_position = msg
 
     def check_mission_abort_status(self) -> None:
-        """Smelly function that does two things, first check incoming leakage status message,
-        then checks battery level and mission time. These are all sources for mission aborts,
-        if any of them is in a trigger state then cancel current mission."""
+        """Cancel the mission when battery, GNSS, depth, or time limits are exceeded."""
         battery_level_threshold = 0.10
         battery_level_low = self.last_seen_battery_level < battery_level_threshold
 
@@ -343,7 +334,7 @@ class NavigationActionClient(Node):
 
         gnss_timeout = (time() - self.last_gnss_update_time) > GNSS_TIMEOUT_S
 
-        # TODO: add leakage detected to this check
+        # Leak is alert-only (leakage/status → MQTT). Not a mission abort trigger.
         if any([battery_level_low, mission_time_exceeded, gnss_timeout, self.is_too_deep]) and self.goals_in_progress:
             self.logger.info(
                 f"Battery low: {battery_level_low}\t"

--- a/src/eel/eel/navigation/navigation_action_server.py
+++ b/src/eel/eel/navigation/navigation_action_server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+from threading import Lock
 from time import sleep, time
 from typing import TYPE_CHECKING, Optional, TypeAlias
 
@@ -45,6 +46,8 @@ class NavigationActionServer(Node):
         super().__init__("navigation_action_server", parameter_overrides=[])
         self.logger = self.get_logger()
         self.current_goal: NavigateGoalHandle | None = None
+        self._goal_in_progress = False
+        self._goal_lock = Lock()
 
         self._action_server = ActionServer(
             self,
@@ -109,13 +112,15 @@ class NavigationActionServer(Node):
         self.publish_rudder_cmd(0.0)
 
     def handle_accepted_callback(self, goal_handle: NavigateGoalHandle) -> None:
-        if self.current_goal is None:
-            self.current_goal = goal_handle
-            self.current_goal.execute()
-        else:
-            self.logger.info("Goal in progress. Cancel before asking for another goal.")
+        self.current_goal = goal_handle
+        self.current_goal.execute()
 
     def goal_callback(self, goal_request: Navigate.Goal) -> GoalResponse:
+        with self._goal_lock:
+            if self._goal_in_progress:
+                self.logger.info("Goal in progress. Rejecting new goal.")
+                return GoalResponse.REJECT
+
         if not has_navigation_pose(self.current_position):
             self.logger.info("No gps position has been acquired yet, rejecting goal.")
             return GoalResponse.REJECT
@@ -130,9 +135,13 @@ class NavigationActionServer(Node):
 
         # Simple sanity check that the target is not to far away, could be removed
         if distance_to_target < TARGET_DISTANCE_LIMIT:
+            with self._goal_lock:
+                if self._goal_in_progress:
+                    self.logger.info("Goal in progress. Rejecting new goal.")
+                    return GoalResponse.REJECT
+                self._goal_in_progress = True
             self.logger.info(f"Accepted new target, lat: {goal_request.goal.lat} lon: {goal_request.goal.lon}")
             self.logger.info(f"Distance to new target: {distance_to_target}m")
-
             return GoalResponse.ACCEPT
         else:
             self.logger.info(
@@ -144,7 +153,6 @@ class NavigationActionServer(Node):
 
     def cancel_callback(self, goal_handle: NavigateGoalHandle) -> CancelResponse:
         self.logger.info("Goal cancel request received, turning off motors.")
-        self.current_goal = None
         self.stop_navigation_actuators()
 
         return CancelResponse.ACCEPT
@@ -188,52 +196,52 @@ class NavigationActionServer(Node):
         self.goal_handle.publish_feedback(feedback_msg)
 
     def execute_callback(self, goal_handle: NavigateGoalHandle) -> Navigate.Result:
-        if not has_navigation_pose(self.current_position):
-            self.logger.error("No current position at execute time, aborting goal.")
-            self.stop_navigation_actuators()
-            self.current_goal = None
-            goal_handle.abort()
-            result = Navigate.Result()
-            result.success = False
-            return result
-
-        self.goal_handle = goal_handle
-
-        goal_request: Navigate.Goal = goal_handle.request
-        self.assignment = self.create_assignment(goal_request)
-
-        next_coordinate = goal_request.goal
-        # TODO: print distance to target here.
-        self.logger.info(
-            f"Executing new goal, target set to {next_coordinate.lat=} "
-            f"{next_coordinate.lon=}, {self.distance_to_target=}"
-        )
-
-        self.assignment.start()
-
-        while not goal_handle.is_cancel_requested and not self.assignment.get_is_done():
-            progress = self.assignment.step(
-                current_position=LatLon(lat=self.current_position.lat, lon=self.current_position.lon),
-                current_heading=self.current_heading,
-                current_depth=self.current_depth,
-                current_time_seconds=time(),
-            )
-            goal_handle.publish_feedback(Navigate.Feedback(distance_to_target=progress["distance_to_target"]))
-
-            sleep(SLEEP_TIME)
-
-        if not goal_handle.is_cancel_requested:
-            goal_handle.succeed()
-        else:
-            goal_handle.canceled()
-        self.current_goal = None
-        self.logger.info("Finished goal.")
-        self.stop_navigation_actuators()
-
         result = Navigate.Result()
-        result.success = not goal_handle.is_cancel_requested
+        try:
+            if not has_navigation_pose(self.current_position):
+                self.logger.error("No current position at execute time, aborting goal.")
+                goal_handle.abort()
+                result.success = False
+                return result
 
-        return result
+            self.goal_handle = goal_handle
+
+            goal_request: Navigate.Goal = goal_handle.request
+            self.assignment = self.create_assignment(goal_request)
+
+            next_coordinate = goal_request.goal
+            # TODO: print distance to target here.
+            self.logger.info(
+                f"Executing new goal, target set to {next_coordinate.lat=} "
+                f"{next_coordinate.lon=}, {self.distance_to_target=}"
+            )
+
+            self.assignment.start()
+
+            while not goal_handle.is_cancel_requested and not self.assignment.get_is_done():
+                progress = self.assignment.step(
+                    current_position=LatLon(lat=self.current_position.lat, lon=self.current_position.lon),
+                    current_heading=self.current_heading,
+                    current_depth=self.current_depth,
+                    current_time_seconds=time(),
+                )
+                goal_handle.publish_feedback(Navigate.Feedback(distance_to_target=progress["distance_to_target"]))
+
+                sleep(SLEEP_TIME)
+
+            if not goal_handle.is_cancel_requested:
+                goal_handle.succeed()
+            else:
+                goal_handle.canceled()
+
+            result.success = not goal_handle.is_cancel_requested
+            return result
+        finally:
+            with self._goal_lock:
+                self._goal_in_progress = False
+            self.current_goal = None
+            self.stop_navigation_actuators()
+            self.logger.info("Finished goal.")
 
 
 def main(args: Optional[list[str]] = None) -> None:

--- a/src/eel/eel/tank/tank_node.py
+++ b/src/eel/eel/tank/tank_node.py
@@ -272,11 +272,18 @@ class TankNode(Node):
         if self.target_level is None:
             return
 
-        level_error = abs(level_average - self.target_level)
-
-        if level_error < 0.01:
+        if is_at_floor(level_average) and self.target_level <= level_average:
             self.tank.stop()
             self.tank_motor_pid.reset_cumulative_error()
+            self.target_status = "floor_reached"
+        elif is_at_ceiling(level_average) and self.target_level >= level_average:
+            self.tank.stop()
+            self.tank_motor_pid.reset_cumulative_error()
+            self.target_status = "ceiling_reached"
+        elif is_within_accepted_target_boundaries(level_average, self.target_level):
+            self.tank.stop()
+            self.tank_motor_pid.reset_cumulative_error()
+            self.target_status = "target_reached"
         else:
             if self.clamp_value <= self.clamp_max_value:
                 self.clamp_value += 0.05


### PR DESCRIPTION
## Summary
- **#155** — Modem startup no longer crashes when registration status or RSSI is `0` (valid value, not missing)
- **#200** — Navigate server rejects new goals while one is already running instead of accepting and silently ignoring them
- **#142** — Tank pump stops at floor/ceiling when level never reaches target, preventing endless run on bad sensor readings
- **#146** — Cancelled dive ends with `canceled()` after surfacing instead of reporting success
- **#140** — Remove unused leak subscription/abort wiring from nav client; document alert-only policy (leak still flows via `leakage/status` → MQTT)
- **#214** — LED node releases GPIO on shutdown so the pin is not left claimed after restart

Fixes #155, #200, #142, #146, #140, #214

## Test plan
- [x] `source source_me.sh && make test` (per commit)
- [ ] Modem node starts when RSSI/reg reports `0`
- [ ] Second navigate goal while first is running is rejected
- [ ] Tank target loop stops at floor/ceiling limits
- [ ] Cancel dive → action result is canceled, not succeeded
- [ ] LED node exit turns off LED and releases pin