### PR TITLE
fix: small batch — serial, battery units, motor watchdog, LED pulses

### DIFF
--- a/source_me.sh
+++ b/source_me.sh
@@ -24,8 +24,11 @@ echo "Using $FILE_EXT"
 
 # Auto-detect or use ROS_DISTRO
 if [ -z "$ROS_DISTRO" ]; then
-  # Try to find the latest installed ROS distro
-  ROS_DISTRO=$(ls /opt/ros | sort | tail -n 1)
+  [ "$(ls /opt/ros 2>/dev/null | wc -l)" -eq 1 ] || {
+    echo "Set ROS_DISTRO first (found: $(ls /opt/ros 2>/dev/null)). e.g. export ROS_DISTRO=jazzy && source source_me.sh"
+    return 1 2>/dev/null || exit 1
+  }
+  ROS_DISTRO=$(ls /opt/ros)
   echo "Auto-detected ROS_DISTRO: $ROS_DISTRO"
 fi
 

--- a/src/eel/eel/battery/battery_node.py
+++ b/src/eel/eel/battery/battery_node.py
@@ -25,12 +25,12 @@ class BatteryNode(Node):
 
         sensor: BatterySensor | BatterySimulator
         sensor = BatterySensor() if not self.should_simulate else BatterySimulator(parent_node=self)
-        self.get_voltage = sensor.get_voltage
-        self.get_current = sensor.get_current
-        self.get_power = sensor.get_power
-        self.get_supply_voltage = sensor.get_supply_voltage
-        self.get_shunt_voltage = sensor.get_shunt_voltage
-        self.get_voltage_percent = sensor.get_voltage_percent
+        self.get_voltage_v = sensor.get_voltage_v
+        self.get_current_a = sensor.get_current_a
+        self.get_power_w = sensor.get_power_w
+        self.get_supply_voltage_v = sensor.get_supply_voltage_v
+        self.get_shunt_voltage_v = sensor.get_shunt_voltage_v
+        self.get_voltage_ratio = sensor.get_voltage_ratio
 
         self.updater = self.create_timer(1.0 / self.update_frequency, self.publish_battery)
 
@@ -38,12 +38,12 @@ class BatteryNode(Node):
 
     def publish_battery(self) -> None:
         msg = BatteryStatus()
-        msg.voltage = self.get_voltage()
-        msg.current = self.get_current()
-        msg.power = self.get_power()
-        msg.supply_voltage = self.get_supply_voltage()
-        msg.shunt_voltage = self.get_shunt_voltage()
-        msg.voltage_percent = self.get_voltage_percent()
+        msg.voltage_v = self.get_voltage_v()
+        msg.current_a = self.get_current_a()
+        msg.power_w = self.get_power_w()
+        msg.supply_voltage_v = self.get_supply_voltage_v()
+        msg.shunt_voltage_v = self.get_shunt_voltage_v()
+        msg.voltage_ratio = self.get_voltage_ratio()
 
         self.status_publisher.publish(msg)
 

--- a/src/eel/eel/battery/battery_sensor.py
+++ b/src/eel/eel/battery/battery_sensor.py
@@ -1,4 +1,4 @@
-from .battery_utils import calculate_voltage_percent
+from .battery_utils import calculate_voltage_ratio
 
 
 class BatterySensor:
@@ -10,34 +10,20 @@ class BatterySensor:
         self.ina = INA226(busnum=1, max_expected_amps=16, log_level=logging.INFO)
         self.ina.configure()
 
-    # TODO: not percent. change name to get_voltage_ratio
-    def get_voltage_percent(self) -> float:
-        voltage = self.ina.voltage()
-        percent = calculate_voltage_percent(voltage)
-        return float(percent / 100)
+    def get_voltage_ratio(self) -> float:
+        return calculate_voltage_ratio(self.ina.voltage())
 
-    # NOTE: unit is V
-    # TODO: include unit in name
-    def get_voltage(self) -> float:
+    def get_voltage_v(self) -> float:
         return float(self.ina.voltage())
 
-    # NOTE: unit is mA
-    # TODO: include unit in name
-    def get_current(self) -> float:
-        return float(self.ina.current())
+    def get_current_a(self) -> float:
+        return float(self.ina.current()) / 1000.0
 
-    # NOTE: unit is mW
-    # TODO: divide by 1000 so that unit is W
-    # TODO: include unit in name
-    def get_power(self) -> float:
-        return float(self.ina.power())
+    def get_power_w(self) -> float:
+        return float(self.ina.power()) / 1000.0
 
-    # NOTE: unit is V
-    # TODO: include unit in name
-    def get_supply_voltage(self) -> float:
+    def get_supply_voltage_v(self) -> float:
         return float(self.ina.supply_voltage())
 
-    # NOTE: unit is V
-    # TODO: include unit in name
-    def get_shunt_voltage(self) -> float:
-        return float(self.ina.shunt_voltage())
+    def get_shunt_voltage_v(self) -> float:
+        return float(self.ina.shunt_voltage()) / 1000.0

--- a/src/eel/eel/battery/battery_sim.py
+++ b/src/eel/eel/battery/battery_sim.py
@@ -2,7 +2,7 @@ from time import time
 
 from rclpy.node import Node
 
-from .battery_utils import calculate_voltage_percent
+from .battery_utils import calculate_voltage_ratio
 
 BATTERY_MAX_VOLTAGE = 16.8
 DEGENERATION_TIME_S = 30
@@ -12,11 +12,11 @@ DEGEN_RATE_PERCENT = 0.00
 class BatterySimulator:
     def __init__(self, parent_node: Node) -> None:
         self.start_time = time()
-        self.voltage = BATTERY_MAX_VOLTAGE
-        self.current = 2.56
-        self.power = self.voltage * self.current
-        self.supply_voltage = self.voltage
-        self.shunt_voltage = self.voltage
+        self.voltage_v = BATTERY_MAX_VOLTAGE
+        self.current_a = 2.56
+        self.power_w = self.voltage_v * self.current_a
+        self.supply_voltage_v = self.voltage_v
+        self.shunt_voltage_v = 0.0
 
         self.last_update = self.start_time
 
@@ -30,24 +30,24 @@ class BatterySimulator:
         now = time()
 
         if (int(now) - int(self.start_time)) % DEGENERATION_TIME_S == 0:
-            self.voltage = self.voltage - (BATTERY_MAX_VOLTAGE * DEGEN_RATE_PERCENT)
+            self.voltage_v = self.voltage_v - (BATTERY_MAX_VOLTAGE * DEGEN_RATE_PERCENT)
+            self.supply_voltage_v = self.voltage_v
+            self.power_w = self.voltage_v * self.current_a
 
-    def get_voltage(self) -> float:
-        return self.voltage
+    def get_voltage_v(self) -> float:
+        return self.voltage_v
 
-    def get_voltage_percent(self) -> float:
-        voltage = self.get_voltage()
-        percent = calculate_voltage_percent(voltage)
-        return float(percent / 100)
+    def get_voltage_ratio(self) -> float:
+        return calculate_voltage_ratio(self.get_voltage_v())
 
-    def get_current(self) -> float:
-        return self.current
+    def get_current_a(self) -> float:
+        return self.current_a
 
-    def get_power(self) -> float:
-        return self.power
+    def get_power_w(self) -> float:
+        return self.power_w
 
-    def get_supply_voltage(self) -> float:
-        return self.supply_voltage
+    def get_supply_voltage_v(self) -> float:
+        return self.supply_voltage_v
 
-    def get_shunt_voltage(self) -> float:
-        return self.shunt_voltage
+    def get_shunt_voltage_v(self) -> float:
+        return self.shunt_voltage_v

--- a/src/eel/eel/battery/battery_utils.py
+++ b/src/eel/eel/battery/battery_utils.py
@@ -23,12 +23,11 @@ percent_voltage_map = {
 }
 
 
-def calculate_voltage_percent(voltage: float) -> float:
+def calculate_voltage_ratio(voltage: float) -> float:
     percent = 0.0
 
     if voltage >= percent_voltage_map[100]:
-        percent = 100.0
-        return percent
+        return 1.0
 
     for mapped_percent, mapped_voltage in percent_voltage_map.items():
         if voltage < mapped_voltage:
@@ -37,4 +36,4 @@ def calculate_voltage_percent(voltage: float) -> float:
             percent = mapped_percent
             break
 
-    return percent
+    return percent / 100.0

--- a/src/eel/eel/gnss/gnss_node.py
+++ b/src/eel/eel/gnss/gnss_node.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import rclpy
 from rclpy.node import Node
+from rclpy.parameter import Parameter
 
 from eel_interfaces.msg import Coordinate
 
@@ -31,8 +32,11 @@ class GNSS(Node):
         else:
             from .gnss_sensor import GnssSensor
 
-            self.declare_parameter("serial_port", "/dev/ttyUSB1")
-            serial_port = self.get_parameter("serial_port").get_parameter_value().string_value
+            self.declare_parameter("serial_port", Parameter.Type.STRING)
+            # ROS string params are "" when unset — not Python None.
+            serial_port = self.get_parameter("serial_port").get_parameter_value().string_value or None
+            if serial_port is None:
+                raise ValueError("serial_port is required when not simulating")
             source = GnssSensor(serial_port=serial_port)
 
         self.get_current_position = source.get_current_position

--- a/src/eel/eel/gnss/gnss_sensor.py
+++ b/src/eel/eel/gnss/gnss_sensor.py
@@ -9,7 +9,7 @@ logger = get_logger(__name__)
 
 
 class GnssSensor:
-    def __init__(self, serial_port: str = "/dev/ttyUSB1") -> None:
+    def __init__(self, serial_port: str) -> None:
         self._position_lock = threading.Lock()
         self.current_lat: float | None = None
         self.current_lon: float | None = None

--- a/src/eel/eel/led_control/led_node.py
+++ b/src/eel/eel/led_control/led_node.py
@@ -3,14 +3,24 @@ from typing import Optional
 
 import rclpy
 from rclpy.node import Node
+from rclpy.timer import Timer
 
 from eel_interfaces.msg import NavigationStatus
 
 from ..utils.constants import SIMULATE_PARAM, NavigationMissionStatus
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import NAVIGATION_STATUS
+from .led_pulse import PulseStep, plan_pulse_steps
 from .led_sim import LEDBackend, LEDSimulator
 
+# Every SEQUENCE_PERIOD_S the LED plays one pattern for the current mission status.
+# Each character ≈ 0.1s. '#' = on, ' ' = off (gap between pulses is essentially instant).
+#
+# waiting    2×0.50s   ##### #####................
+# acquired   3×0.25s   ## ## ##...................
+# started    4×0.10s   # # # #....................
+# cancelled  1×1.50s   ###############............
+# finished   6×0.25s   ## ## ## ## ## ##..........
 PULSE_COUNT_MAP = {
     NavigationMissionStatus.WAITING_FOR_MISSION.value: 2,
     NavigationMissionStatus.MISSION_AQUIRED.value: 3,
@@ -26,6 +36,8 @@ PULSE_TIME_MAP = {
     NavigationMissionStatus.MISSION_CANCELLED.value: 1.5,
     NavigationMissionStatus.MISSION_FINISHED.value: 0.25,
 }
+
+SEQUENCE_PERIOD_S = 3.0
 
 
 class LED(Node):
@@ -47,8 +59,11 @@ class LED(Node):
             NavigationStatus, NAVIGATION_STATUS, self.update_mission_status, 10
         )
 
-        self.poller = self.create_timer(3.0, self.pulse_led)
         self.navigation_status = NavigationMissionStatus.WAITING_FOR_MISSION.value
+        self._pulse_steps: list[PulseStep] = []
+        self._pulse_timer: Timer = self.create_timer(1.0, self._on_pulse_timer)
+        self._pulse_timer.cancel()
+        self.create_timer(SEQUENCE_PERIOD_S, self.pulse_led)
 
         self.get_logger().info(f"{'SIMULATE ' if self.should_simulate else ''}LED node started.")
 
@@ -56,13 +71,41 @@ class LED(Node):
         self.navigation_status = msg.mission_status
 
     def pulse_led(self) -> None:
+        if self._pulse_steps:
+            return
+
         nof_pulses = PULSE_COUNT_MAP.get(self.navigation_status)
         pulse_length = PULSE_TIME_MAP.get(self.navigation_status)
+        if nof_pulses is None or pulse_length is None:
+            return
 
-        if nof_pulses is not None and pulse_length is not None:
-            self.led_control.sequence(nof_pulses, pulse_length)
+        self._pulse_steps = plan_pulse_steps(nof_pulses, pulse_length)
+        self._run_pulse_step()
+
+    def _on_pulse_timer(self) -> None:
+        self._run_pulse_step()
+
+    def _run_pulse_step(self) -> None:
+        if not self._pulse_steps:
+            self._pulse_timer.cancel()
+            return
+
+        action, delay_s = self._pulse_steps.pop(0)
+        if action == "on":
+            self.led_control.on()
+        else:
+            self.led_control.off()
+
+        if delay_s > 0:
+            self._pulse_timer.timer_period_ns = int(delay_s * 1e9)
+            self._pulse_timer.reset()
+        else:
+            self._run_pulse_step()
 
     def shutdown(self) -> None:
+        self._pulse_timer.cancel()
+        self._pulse_steps = []
+        self.led_control.off()
         if self._led_control is not None:
             self._led_control.close()
 

--- a/src/eel/eel/led_control/led_pulse.py
+++ b/src/eel/eel/led_control/led_pulse.py
@@ -1,0 +1,19 @@
+from typing import Literal
+
+PulseAction = Literal["on", "off"]
+PulseStep = tuple[PulseAction, float]
+
+
+def plan_pulse_steps(nof_pulses: int, pulse_time: float) -> list[PulseStep]:
+    """Build on/off steps matching the old blocking sequence() timing.
+
+    For each pulse: turn on, wait pulse_time, turn off (no gap before the next on).
+    """
+    if nof_pulses <= 0 or pulse_time < 0:
+        return []
+
+    steps: list[PulseStep] = []
+    for _ in range(nof_pulses):
+        steps.append(("on", pulse_time))
+        steps.append(("off", 0.0))
+    return steps

--- a/src/eel/eel/led_control/led_sim.py
+++ b/src/eel/eel/led_control/led_sim.py
@@ -2,9 +2,6 @@ from typing import Protocol
 
 
 class LEDBackend(Protocol):
-    def sequence(self, nof_pulses: int = 3, pulse_time: float = 0.1) -> None:
-        pass
-
     def on(self) -> None:
         pass
 
@@ -13,9 +10,6 @@ class LEDBackend(Protocol):
 
 
 class LEDSimulator:
-    def sequence(self, nof_pulses: int = 3, pulse_time: float = 0.1) -> None:
-        pass
-
     def on(self) -> None:
         pass
 

--- a/src/eel/eel/motor/motor_node.py
+++ b/src/eel/eel/motor/motor_node.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from time import monotonic
 from typing import Callable, Optional
 
 import rclpy
@@ -10,15 +11,23 @@ from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import MOTOR_CMD
 from ..utils.utils import clamp
 from .motor_sim import MotorSimulator
+from .motor_watchdog import command_is_stale, require_positive_cmd_timeout
+
+MOTOR_CMD_TIMEOUT_PARAM = "cmd_timeout_s"
+DEFAULT_MOTOR_CMD_TIMEOUT_S = 1.0
+WATCHDOG_CHECK_PERIOD_S = 0.2
 
 
 class Motor(Node):
     def __init__(self) -> None:
         super().__init__("motor_node")
         self.declare_parameter(SIMULATE_PARAM, False)
+        self.declare_parameter(MOTOR_CMD_TIMEOUT_PARAM, DEFAULT_MOTOR_CMD_TIMEOUT_S)
         self.should_simulate = self.get_parameter(SIMULATE_PARAM).value
+        self.cmd_timeout_s = require_positive_cmd_timeout(float(self.get_parameter(MOTOR_CMD_TIMEOUT_PARAM).value))
 
         self.motor_subscription = self.create_subscription(Float32, MOTOR_CMD, self.handle_motor_msg, 10)
+        self._last_cmd_at: float | None = None
 
         stop: Callable[[], None]
         forward: Callable[[float], None]
@@ -41,7 +50,14 @@ class Motor(Node):
         self.forward = forward
         self.backward = backward
 
-        self.get_logger().info("{}Motor node started.".format("SIMULATE " if self.should_simulate else ""))
+        self.create_timer(WATCHDOG_CHECK_PERIOD_S, self._watchdog_tick)
+
+        self.get_logger().info(
+            "{}Motor node started (cmd_timeout_s={}).".format(
+                "SIMULATE " if self.should_simulate else "",
+                self.cmd_timeout_s,
+            )
+        )
 
     def shutdown(self) -> None:
         self.stop()
@@ -52,10 +68,19 @@ class Motor(Node):
         motor_value = clamp(msg.data, -1, 1)
         if motor_value == 0:
             self.stop()
-        elif motor_value > 0:
+            self._last_cmd_at = None
+            return
+        self._last_cmd_at = monotonic()
+        if motor_value > 0:
             self.forward(signal=motor_value)
-        elif motor_value < 0:
+        else:
             self.backward(signal=abs(motor_value))
+
+    def _watchdog_tick(self) -> None:
+        if command_is_stale(self._last_cmd_at, monotonic(), self.cmd_timeout_s):
+            self.get_logger().warning("motor/cmd stale; stopping motor")
+            self.stop()
+            self._last_cmd_at = None
 
 
 def main(args: Optional[list[str]] = None) -> None:

--- a/src/eel/eel/motor/motor_watchdog.py
+++ b/src/eel/eel/motor/motor_watchdog.py
@@ -1,0 +1,11 @@
+def command_is_stale(last_cmd_at: float | None, now: float, timeout_s: float) -> bool:
+    """True when a command was seen before and silence exceeded timeout_s."""
+    if last_cmd_at is None:
+        return False
+    return (now - last_cmd_at) > timeout_s
+
+
+def require_positive_cmd_timeout(timeout_s: float) -> float:
+    if timeout_s <= 0:
+        raise ValueError(f"cmd_timeout_s must be > 0, got {timeout_s}")
+    return timeout_s

--- a/src/eel/eel/mqtt_bridge/node.py
+++ b/src/eel/eel/mqtt_bridge/node.py
@@ -81,7 +81,7 @@ class ImuOffsetsMqtt(TypedDict):
 
 
 class BatteryStatusMqtt(TypedDict):
-    voltage_percent: float
+    voltage_ratio: float
 
 
 class FloatMsgMqtt(TypedDict):
@@ -126,7 +126,7 @@ SubscriberCallback = Callable[[str, bytes, bool, object, bool], None]
 
 
 def transform_battery_msg(msg: BatteryStatus) -> BatteryStatusMqtt:
-    return {"voltage_percent": msg.voltage_percent}
+    return {"voltage_ratio": msg.voltage_ratio}
 
 
 def transform_imu_msg(msg: ImuStatus) -> ImuStatusMqtt:

--- a/src/eel/eel/navigation/assignments.py
+++ b/src/eel/eel/navigation/assignments.py
@@ -154,6 +154,7 @@ class WaypointAndDepth(Assignment):
         next_rudder_turn = get_next_rudder_turn(current_heading, desired_heading)
 
         self.on_set_rudder(next_rudder_turn)
+        self.on_set_motor(1.0)
 
         return {"distance_to_target": distance_to_target}
 

--- a/src/eel/eel/navigation/navigation_action_client.py
+++ b/src/eel/eel/navigation/navigation_action_client.py
@@ -244,7 +244,7 @@ class NavigationActionClient(Node):
 
         self.updater = self.create_timer(1.0, self.publish_status)
 
-        self.last_seen_battery_level = 100.0
+        self.last_seen_battery_level = 1.0
 
         self.current_position: Coordinate | None = None
 
@@ -317,7 +317,7 @@ class NavigationActionClient(Node):
 
     def handle_battery_status(self, msg: BatteryStatus) -> None:
         """Updates the last seen battery level variable."""
-        self.last_seen_battery_level = msg.voltage_percent
+        self.last_seen_battery_level = msg.voltage_ratio
 
     def handle_localization_update(self, msg: Coordinate) -> None:
         self.current_position = msg

--- a/src/eel/eel/pressure/pressure_node.py
+++ b/src/eel/eel/pressure/pressure_node.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import rclpy
 from rclpy.node import Node
+from rclpy.parameter import Parameter
 
 from eel_interfaces.msg import ImuStatus, PressureStatus
 
@@ -36,7 +37,7 @@ def get_depth_velocity(
     return velocity
 
 
-def get_pressure_sensor(should_simulate: bool, parent_node: Node, serial_port: str) -> PressureSource:
+def get_pressure_sensor(should_simulate: bool, parent_node: Node, serial_port: str | None = None) -> PressureSource:
     if should_simulate:
         from .pressure_sim import PressureSensorSimulator
 
@@ -44,22 +45,25 @@ def get_pressure_sensor(should_simulate: bool, parent_node: Node, serial_port: s
     else:
         from .pressure_sensor import PressureSensor
 
+        if serial_port is None:
+            raise ValueError("serial_port is required when not simulating")
         return PressureSensor(parent_node=parent_node, serial_port=serial_port)
 
 
-# example usage: ros2 run eel pressure
+# example usage: ros2 run eel pressure --ros-args -p serial_port:=/dev/ttyUSB0
 class PressureNode(Node):
     def __init__(self) -> None:
         super().__init__("pressure_node")
         self.declare_parameter(SIMULATE_PARAM, False)
         self.should_simulate = bool(self.get_parameter(SIMULATE_PARAM).value)
 
-        # At the time of writing, Ålen uses /dev/ttyUSB1 (which is why it's the default)
-        # and we don't really know which one Tvålen should use.
-        self.declare_parameter("serial_port", "/dev/ttyUSB1")
-        serial_port = self.get_parameter("serial_port").get_parameter_value().string_value
-
-        self.sensor = get_pressure_sensor(self.should_simulate, self, serial_port)
+        if self.should_simulate:
+            self.sensor = get_pressure_sensor(True, self)
+        else:
+            self.declare_parameter("serial_port", Parameter.Type.STRING)
+            # ROS string params are "" when unset — not Python None.
+            serial_port = self.get_parameter("serial_port").get_parameter_value().string_value or None
+            self.sensor = get_pressure_sensor(False, self, serial_port)
 
         self.current_pitch = 0.0
 

--- a/src/eel/eel/pressure/pressure_sensor.py
+++ b/src/eel/eel/pressure/pressure_sensor.py
@@ -25,15 +25,15 @@ class PressureSensor(PressureSource):
 
         self.atmosphere_offset = self._get_initial_depth(retries=number_of_retries)
 
-        if not self.atmosphere_offset:
-            raise Exception(f"Could not determine atmosphere offset after {number_of_retries} retries.")
+        if self.atmosphere_offset is None:
+            raise RuntimeError(f"Could not determine atmosphere offset after {number_of_retries} retries.")
 
-        self.logger.info(f"Sensor initialized, fluid density set to 997 km/m3, offset is {self.atmosphere_offset} m")
+        self.logger.info(f"Sensor initialized, fluid density set to 997 kg/m3, offset is {self.atmosphere_offset} m")
 
     def _get_initial_depth(self, retries: int = 10, sleep_time: float = 0.2) -> float | None:
         for i in range(retries):
             depth = self._get_depth_reading()
-            if depth:
+            if depth is not None:
                 return depth
             self.logger.info("Retrying getting initial depth...")
             time.sleep(sleep_time)
@@ -61,6 +61,6 @@ class PressureSensor(PressureSource):
 
     def get_current_depth(self) -> float | None:
         depth = self._get_depth_reading()
-        if depth and self.atmosphere_offset:
+        if depth is not None and self.atmosphere_offset is not None:
             return depth - self.atmosphere_offset
         return None

--- a/src/eel/eel/pressure/pressure_sim.py
+++ b/src/eel/eel/pressure/pressure_sim.py
@@ -1,54 +1,20 @@
-import random
 from math import radians, tan
 from time import time
 
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
-from eel_interfaces.msg import ImuStatus, TankStatus
+from eel_interfaces.msg import ImuStatus
 
-from ..utils.topics import FRONT_TANK_STATUS, IMU_STATUS, MOTOR_CMD, REAR_TANK_STATUS
+from ..utils.topics import IMU_STATUS, MOTOR_CMD
 from .pressure_source import PressureSource
 
-NEUTRAL_LEVEL = 0.5
-NEUTRAL_TOLERANCE = 0.02
 TERMINAL_VELOCITY_MPS = 0.3
+# Slight positive buoyancy: float up when not actively diving (rudder depth-control era).
+FLOAT_VELOCITY_MPS = -0.05
 
 MAX_DEPTH = 10.0
 MIN_DEPTH = 0.0
-
-# TODO: remove this completely, if it turns out that we don't get OSErrors anymore
-OS_ERROR_RATE = 0.0
-
-
-def should_raise_oserror() -> bool:
-    return random.random() < OS_ERROR_RATE
-
-
-def get_neutral_offset(tank_level: float, neutral_level: float, neutral_tolerance: float) -> float:
-    neutral_ceiling = neutral_level + neutral_tolerance
-    neutral_floor = neutral_level - neutral_tolerance
-    if tank_level < neutral_floor:
-        return tank_level - neutral_floor
-    if tank_level > neutral_ceiling:
-        return tank_level - neutral_ceiling
-    return 0
-
-
-def get_average_bouyancy(
-    front_tank_level: float,
-    rear_tank_level: float,
-    neutral_level: float,
-    neutral_tolerance: float,
-) -> float:
-    front_offset = get_neutral_offset(front_tank_level, neutral_level, neutral_tolerance)
-    rear_offset = get_neutral_offset(rear_tank_level, neutral_level, neutral_tolerance)
-    offset_average = (front_offset + rear_offset) / 2
-    return offset_average
-
-
-def get_velocity(terminal_velocity: float, fraction_of_velocity: float) -> float:
-    return terminal_velocity * fraction_of_velocity
 
 
 def get_pitch_speed_velocity(terminal_velocity: float, pitch: float) -> float:
@@ -69,29 +35,15 @@ def cap_depth(depth: float, min_depth: float, max_depth: float) -> float:
 
 class PressureSensorSimulator(PressureSource):
     def __init__(self, parent_node: Node) -> None:
-        parent_node.create_subscription(TankStatus, FRONT_TANK_STATUS, self._handle_front_tank_msg, 10)
-        parent_node.create_subscription(TankStatus, REAR_TANK_STATUS, self._handle_rear_tank_msg, 10)
-
         parent_node.create_subscription(ImuStatus, IMU_STATUS, self._handle_imu_msg, 10)
-
         parent_node.create_subscription(Float32, MOTOR_CMD, self.handle_motor_msg, 10)
 
         self._last_updated_at = time()
         self._current_motor_speed = 0.0
         self._current_depth = 0.0
-        self._front_tank_level = 0.0
-        self._rear_tank_level = 0.0
         self._current_pitch = 0.0
 
         self.logger = parent_node.get_logger()
-
-    def _handle_front_tank_msg(self, msg: TankStatus) -> None:
-        self._front_tank_level = msg.current_level
-        self._calculate_depth()
-
-    def _handle_rear_tank_msg(self, msg: TankStatus) -> None:
-        self._rear_tank_level = msg.current_level
-        self._calculate_depth()
 
     def _handle_imu_msg(self, msg: ImuStatus) -> None:
         self._current_pitch = msg.pitch
@@ -102,33 +54,20 @@ class PressureSensorSimulator(PressureSource):
         self._calculate_depth()
 
     def _calculate_depth(self) -> None:
-        _ = get_average_bouyancy(
-            self._front_tank_level,
-            self._rear_tank_level,
-            NEUTRAL_LEVEL,
-            NEUTRAL_TOLERANCE,
-        )
-        # NOTE: setting to negative here, so it will float up when motor not running
-        tank_velocity = -0.05  # get_velocity(TERMINAL_VELOCITY_MPS, average_bouyancy)
         pitch_speed_velocity = (
             get_pitch_speed_velocity(TERMINAL_VELOCITY_MPS, self._current_pitch) * self._current_motor_speed
         )
-        velocity = tank_velocity + pitch_speed_velocity
+        velocity = FLOAT_VELOCITY_MPS + pitch_speed_velocity
 
+        now = time()
         if velocity != 0:
-            now = time()
             time_delta = now - self._last_updated_at
             position_delta = calculate_position_delta(velocity, time_delta)
             new_position = self._current_depth + position_delta
-            capped_depth = cap_depth(new_position, MIN_DEPTH, MAX_DEPTH)
-            self._current_depth = capped_depth
+            self._current_depth = cap_depth(new_position, MIN_DEPTH, MAX_DEPTH)
 
-        self._last_updated_at = time()
+        self._last_updated_at = now
 
     def get_current_depth(self) -> float:
         self._calculate_depth()
-
-        if should_raise_oserror():
-            raise OSError("Simulating OSError")
-
         return self._current_depth

--- a/src/eel/test/eel/led_control/led_pulse_test.py
+++ b/src/eel/test/eel/led_control/led_pulse_test.py
@@ -1,0 +1,18 @@
+from eel.led_control.led_pulse import plan_pulse_steps
+
+
+def test__when_two_pulses__should_alternate_on_off_with_wait_only_while_on() -> None:
+    assert plan_pulse_steps(2, 0.5) == [
+        ("on", 0.5),
+        ("off", 0.0),
+        ("on", 0.5),
+        ("off", 0.0),
+    ]
+
+
+def test__when_zero_pulses__should_return_empty_plan() -> None:
+    assert plan_pulse_steps(0, 0.5) == []
+
+
+def test__when_negative_pulse_time__should_return_empty_plan() -> None:
+    assert plan_pulse_steps(3, -0.1) == []

--- a/src/eel/test/eel/motor/motor_watchdog_test.py
+++ b/src/eel/test/eel/motor/motor_watchdog_test.py
@@ -1,0 +1,25 @@
+from eel.motor.motor_watchdog import command_is_stale, require_positive_cmd_timeout
+
+
+def test__when_no_command_seen__should_not_be_stale() -> None:
+    assert not command_is_stale(last_cmd_at=None, now=10.0, timeout_s=1.0)
+
+
+def test__when_command_within_timeout__should_not_be_stale() -> None:
+    assert not command_is_stale(last_cmd_at=9.5, now=10.0, timeout_s=1.0)
+
+
+def test__when_command_older_than_timeout__should_be_stale() -> None:
+    assert command_is_stale(last_cmd_at=8.0, now=10.0, timeout_s=1.0)
+
+
+def test__when_timeout_is_positive__should_return_it() -> None:
+    assert require_positive_cmd_timeout(1.0) == 1.0
+
+
+def test__when_timeout_is_not_positive__should_raise() -> None:
+    try:
+        require_positive_cmd_timeout(0.0)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError")

--- a/src/eel_interfaces/msg/BatteryStatus.msg
+++ b/src/eel_interfaces/msg/BatteryStatus.msg
@@ -1,6 +1,6 @@
-float32 voltage
-float32 current
-float32 power
-float32 supply_voltage
-float32 shunt_voltage
-float32 voltage_percent
+float32 voltage_v
+float32 current_a
+float32 power_w
+float32 supply_voltage_v
+float32 shunt_voltage_v
+float32 voltage_ratio


### PR DESCRIPTION
## Summary
- Serial, ROS env, pressure, battery, motor, and LED fixes from the Aug small-batch board slice (#182, #173, #199, #187, #169, #141, #213). #174/#153 already closed without code here.
- **Deploy with** [ground-control#54](https://github.com/foxpoint-se/ground-control/pull/54): battery field rename + gamepad 10 Hz motor/rudder stream (else teleop thrust dies after the new 1s motor watchdog).

## Fixes
- Fixes #182 — require `serial_port` on hardware GNSS/pressure (no shared `/dev/ttyUSB1` default)
- Fixes #173 — `source_me.sh` only auto-picks ROS distro when exactly one is installed
- Fixes #199 — pressure treats depth `0.0` as valid (`is not None`)
- Fixes #187 — pressure sim: drop dead tank/OSError paths; keep slight float + pitch×motor
- Fixes #169 — `BatteryStatus` fields/units (`voltage_ratio`, `voltage_v`, `current_a`, `power_w`, …)
- Fixes #141 — motor cmd watchdog (default 1s); nav depth-hold republishes motor each tick
- Fixes #213 — LED blinks via timer steps instead of `sleep()` in the 3s callback

## Test plan
- [ ] `source source_me.sh && make test`
- [ ] Hardware: GNSS + pressure with explicit `serial_port` params; confirm no silent USB collision
- [ ] Battery status fields match GC after #54; values look like V/A/W not mA/mW-as-percent
- [ ] Teleop: with GC #54, thrust holds while stick held; release/disconnect → motor stops ≤1s
- [ ] Nav depth-hold: motor keeps commanding while assignment runs
- [ ] LED: mission-status blink patterns still readable; other nodes keep ticking during blinks