### PR TITLE
fix: safety batch — pressure, PID, tank, GNSS, MQTT bounds, logging, TODO triage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ Longer / maybe-stale bring-up notes live here so the main README stays lean. Age
 
 | Doc | About |
 | --- | ----- |
+| [pressure-depth.md](./pressure-depth.md) | Bar02 → i2c-proxy → eel (binary float serial link) |
 | [gnss-pi-uart-console.md](./gnss-pi-uart-console.md) | Pi miniUART / serial console vs GPS (may be obsolete for USB-only GPS) |
 | [modem-wifi-fallback.md](./modem-wifi-fallback.md) | Idea: start cellular modem if wifi never comes up |
 

--- a/docs/pressure-depth.md
+++ b/docs/pressure-depth.md
@@ -1,0 +1,22 @@
+# Pressure / depth (Bar02)
+
+## Hardware path
+
+```
+Bar02 (MS5837-02BA, I²C)
+  → Arduino Nano running foxpoint-se/i2c-proxy
+  → USB serial (binary floats)
+  → eel pressure node
+```
+
+Bar02 itself is I²C only. We keep that bus short and put the Nano next to the sensor so the long run to the Pi is serial (less noise than a long I²C cable).
+
+## i2c-proxy wire format
+
+Repo: https://github.com/foxpoint-se/i2c-proxy
+
+- Model: `MS5837_02BA`, freshwater density `997` kg/m³ (set on the Arduino)
+- Every 200 ms (5 Hz): `depthSensor.depth()` as **4 little-endian float bytes** on UART @ **9600**
+- No header, checksum, or delimiter — just raw `float32` frames
+
+Bar02 install / I²C: https://bluerobotics.com/learn/bar-sensors-guide/

--- a/src/eel/eel/depth_control/depth_control_node.py
+++ b/src/eel/eel/depth_control/depth_control_node.py
@@ -16,6 +16,7 @@ from eel_interfaces.msg import (
     TankStatus,
 )
 
+from ..utils.actuator_bounds import parse_depth_control_targets
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.pid_controller import PidController
 from ..utils.pid_tuning import get_production_pid_settings
@@ -59,8 +60,6 @@ def is_within_accepted_target_boundaries(current_level: float, target_level: flo
     return is_within_target
 
 
-# TODO: Remove or move somewhere else. Can be useful for when getting depth at center when
-# sensor is placed at one end of the vehicle.
 SIMULATION_VEHICLE_LENGTH = 1  # meters
 
 SIMULATION_PRESSURE_SENSOR_REAR_DISPLACEMENT = 0.5 - SIMULATION_VEHICLE_LENGTH
@@ -82,8 +81,6 @@ class DepthControlNode(Node):
         self.current_front_tank_level: float | None = None
         self.current_rear_tank_level: float | None = None
 
-        # TODO: conditionally set pid settings, based on what we find when tuning hardware
-        # depth_Ku, depth_Tu, pitch_Ku, pitch_Tu = get_simulation_pid_settings()
         depth_Ku, depth_Tu, pitch_Ku, pitch_Tu = get_production_pid_settings()
         self.depth_Ku = depth_Ku
         self.depth_Tu = depth_Tu
@@ -101,7 +98,6 @@ class DepthControlNode(Node):
 
         self.publisher = self.create_publisher(DepthControlStatus, DEPTH_CONTROL_STATUS, 10)
 
-        # TODO: enable these conditionally, for use when tuning PID
         self.pid_publisher = self.create_publisher(Float32, "pid_error", 10)
         self.pid_publisher_base = self.create_publisher(Float32, "pid_error_target", 10)
         self.front_tank_depth_publisher = self.create_publisher(Float32, "front_depth_pid", 10)
@@ -167,16 +163,21 @@ class DepthControlNode(Node):
         )
 
     def handle_cmd_msg(self, msg: DepthControlCmd) -> None:
-        self.depth_target = msg.depth_target
-        self.pitch_target = msg.pitch_target
+        bounded = parse_depth_control_targets(msg.depth_target, msg.pitch_target)
+        if bounded is None:
+            self.logger.warning(
+                f"Rejecting invalid depth control cmd depth={msg.depth_target} pitch={msg.pitch_target}"
+            )
+            return
+        depth_target, pitch_target = bounded
+        if depth_target != msg.depth_target or pitch_target != msg.pitch_target:
+            self.logger.warning(
+                "Clamped depth control cmd "
+                f"depth={msg.depth_target}->{depth_target} pitch={msg.pitch_target}->{pitch_target}"
+            )
+        self.depth_target = depth_target
+        self.pitch_target = pitch_target
 
-        # TODO: Think about fluctuating sensor values — PID noise may cause constant updates.
-        # Maybe kill PIDs inside an accepted target range and re-init when the vehicle drifts.
-        # Or make simulators return fluctuating values so we can test that logic in simulation.
-
-        # depth_Kp, depth_Ki, depth_Kd = lookup_zieglernichols_gains(
-        #     depth_Ku, depth_Tu, msg.depth_pid_type
-        # )
         depth_Kp = 0.25
         depth_Ki = 0.0
         depth_Kd = 0.0
@@ -324,14 +325,6 @@ class DepthControlNode(Node):
 
             self.front_tank_pub.publish(front_msg)
             self.rear_tank_pub.publish(rear_msg)
-
-            # TODO add to status: current depth velocity, current target depth
-            # TODO add to status: current pitch velocity, current target pitch
-            # TODO add to status: status --> going to target, target reached etc
-            # status_msg = DepthControlStatus()
-            # status_msg.is_adjusting_depth = self.should_control_depth
-            # status_msg.is_adjusting_pitch = self.should_control_pitch
-            # self.publisher.publish(status_msg)
 
     def publish_debug_values(self, depth_front_tank: float, pitch_front_tank: float) -> None:
         depth_front_msg = Float32()

--- a/src/eel/eel/depth_control/depth_control_node_rudder.py
+++ b/src/eel/eel/depth_control/depth_control_node_rudder.py
@@ -12,6 +12,7 @@ from eel_interfaces.msg import (
     PressureStatus,
 )
 
+from ..utils.actuator_bounds import bounded_depth_target
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.pid_controller import PidController
 from ..utils.topics import (
@@ -36,8 +37,12 @@ class DepthControlNode(Node):
         self.max_dive_angle = 30.0
         self.max_rudder_output = 1.0
 
-        self.inner_pid_target_angle = PidController(0.0, kP=-35.0, kD=-10.0)
-        self.out_pid_rudder_output = PidController(0.0, kP=1 / 30)
+        self.inner_pid_target_angle = PidController(
+            0.0, kP=-35.0, kD=-10.0, output_min=-self.max_dive_angle, output_max=self.max_dive_angle
+        )
+        self.out_pid_rudder_output = PidController(
+            0.0, kP=1 / 30, output_min=-self.max_rudder_output, output_max=self.max_rudder_output
+        )
 
         self.current_pitch = 0.0
         self.current_depth = 0.0
@@ -76,25 +81,22 @@ class DepthControlNode(Node):
         self.current_depth = msg.depth
 
     def handle_cmd_msg(self, msg: DepthControlCmd) -> None:
-        self.depth_target = msg.depth_target
-        self.inner_pid_target_angle.update_set_point(msg.depth_target)
+        depth_target = bounded_depth_target(msg.depth_target)
+        if depth_target is None:
+            self.logger.warning(f"Rejecting invalid depth control cmd depth={msg.depth_target}")
+            return
+        if depth_target != msg.depth_target:
+            self.logger.warning(f"Clamped depth control cmd depth={msg.depth_target}->{depth_target}")
+        self.depth_target = depth_target
+        self.inner_pid_target_angle.update_set_point(depth_target)
 
     def compute_new_target_angle(self) -> float:
         pid_angle_output = self.inner_pid_target_angle.compute(self.current_depth)
-
-        if abs(pid_angle_output) > self.max_dive_angle:
-            pid_angle_output = self.max_dive_angle if pid_angle_output > 0 else -1 * self.max_dive_angle
-
         return -1 * pid_angle_output
 
     def compute_new_rudder_output(self, new_target_angle: float) -> float:
         self.out_pid_rudder_output.update_set_point(new_target_angle)
-        rudder_output = self.out_pid_rudder_output.compute(self.current_pitch)
-
-        if abs(rudder_output) > self.max_rudder_output:
-            rudder_output = self.max_rudder_output if rudder_output > 0 else -1.0 * self.max_rudder_output
-
-        return rudder_output
+        return self.out_pid_rudder_output.compute(self.current_pitch)
 
 
 def main(args: Optional[list[str]] = None) -> None:

--- a/src/eel/eel/dive/dive_action_server.py
+++ b/src/eel/eel/dive/dive_action_server.py
@@ -52,9 +52,13 @@ class DiveActionServer(Node):
         self.max_dive_time_sec = 120.0
 
         self.angle_pid_output = 0.0
-        self.angle_pid_controller = PidController(0.0, kP=-35, kD=-5)  # Inner PID
+        self.angle_pid_controller = PidController(
+            0.0, kP=-35, kD=-5, output_min=-self.max_dive_angle, output_max=self.max_dive_angle
+        )
+        self.rudder_pid_controller = PidController(
+            0.0, kP=1 / 15, output_min=-self.max_rudder_output, output_max=self.max_rudder_output
+        )
         self.rudder_pid_output = 0.0
-        self.rudder_pid_controller = PidController(0.0, kP=1 / 15)
 
         self.current_depth = 0.0
         self.current_pitch = 0.0
@@ -85,28 +89,11 @@ class DiveActionServer(Node):
 
     def compute_new_target_angle(self) -> float:
         pid_angle_output = self.angle_pid_controller.compute(self.current_depth)
-
-        # Check if the PID is requesting angles larger then max value
-        if abs(pid_angle_output) > self.max_dive_angle:
-            if pid_angle_output > 0:
-                pid_angle_output = self.max_dive_angle
-            else:
-                pid_angle_output = -1 * self.max_dive_angle
-
         return -1 * pid_angle_output
 
     def compute_new_rudder_output(self, target_angle: float) -> float:
         self.rudder_pid_controller.update_set_point(target_angle)
-        rudder_output = self.rudder_pid_controller.compute(self.current_pitch)
-
-        # Check if the PID is requesting servo values larger then max value
-        if abs(rudder_output) > self.max_rudder_output:
-            if rudder_output > 0:
-                rudder_output = self.max_rudder_output
-            else:
-                rudder_output = -1 * self.max_rudder_output
-
-        return rudder_output
+        return self.rudder_pid_controller.compute(self.current_pitch)
 
     def goal_callback(self, goal_request: Dive.Goal) -> GoalResponse:
         if not is_dive_goal_valid(

--- a/src/eel/eel/gnss/gnss_sensor.py
+++ b/src/eel/eel/gnss/gnss_sensor.py
@@ -13,11 +13,9 @@ class GnssSensor:
         self._position_lock = threading.Lock()
         self.current_lat: float | None = None
         self.current_lon: float | None = None
-        # TODO: remove this comment if we don't seem to have problem with timeout=0
         self.serial = SerialReaderWriter(serial_port, baudrate=9600, on_message=self.handle_message)
 
     def handle_message(self, message: str) -> None:
-        # TODO: remove this comment if GGA seems to work instead of GPRMC
         if "GGA" in message:
             try:
                 parsed = pynmea2.parse(message)

--- a/src/eel/eel/imu/imu_node.py
+++ b/src/eel/eel/imu/imu_node.py
@@ -42,7 +42,7 @@ class ImuNode(Node):
         if not self.should_simulate:
             sensor = ImuSensor()
         else:
-            sensor = ImuSimulator(self)
+            sensor = ImuSimulator(parent_node=self, update_frequency_hz=self.update_frequency)
 
         self.sensor = sensor
 
@@ -52,14 +52,6 @@ class ImuNode(Node):
         self.get_imu_offsets = self.sensor.get_calibration_offsets
 
         self.updater = self.create_timer(1.0 / self.update_frequency, self.publish_imu)
-
-        # TODO: clean up the updating stuff. we'll just go with hard-coded constructor for now.
-        # self.imu_offsets_updater = self.create_timer(
-        #     1.0 / self.publish_offsets_freq, self.publish_imu_offsets
-        # )
-        # self.imu_offsets_writer = self.create_timer(
-        #     1.0 / self.update_calibration_offsets_freq, self.write_calibration_offsets
-        # )
 
         self.get_logger().info("{}IMU node started.".format("SIMULATE " if self.should_simulate else ""))
 

--- a/src/eel/eel/imu/imu_sim.py
+++ b/src/eel/eel/imu/imu_sim.py
@@ -1,7 +1,7 @@
 from time import time
-from typing import TYPE_CHECKING
 
 from geometry_msgs.msg import Vector3
+from rclpy.node import Node
 from std_msgs.msg import Float32
 
 from eel_interfaces.msg import TankStatus
@@ -14,10 +14,6 @@ from ..utils.topics import (
     RUDDER_STATUS,
 )
 from .types import CalibrationOffsets
-
-if TYPE_CHECKING:
-    from .imu_node import ImuNode
-
 
 TERMINAL_PITCH_ANGULAR_VELOCITY_DEGPS = 12.5
 MOMENTUM_TOLERANCE = 0.03
@@ -63,7 +59,7 @@ def calculate_angle_delta(angular_velocity: float, time_in_s: float) -> float:
 
 
 class ImuSimulator:
-    def __init__(self, parent_node: "ImuNode") -> None:
+    def __init__(self, parent_node: Node, update_frequency_hz: float) -> None:
         self.current_rudder_status = Vector3()
         self.current_heading = float(0)
         self.speed = 0.0
@@ -83,7 +79,7 @@ class ImuSimulator:
         parent_node.create_subscription(TankStatus, FRONT_TANK_STATUS, self._handle_front_tank_msg, 10)
         parent_node.create_subscription(TankStatus, REAR_TANK_STATUS, self._handle_rear_tank_msg, 10)
 
-        self.imu_updater = parent_node.create_timer(1.0 / (parent_node.update_frequency * 2), self._loop)
+        self.imu_updater = parent_node.create_timer(1.0 / (update_frequency_hz * 2), self._loop)
 
     def _handle_rudder_msg(self, msg: Vector3) -> None:
         self.current_rudder_status = msg

--- a/src/eel/eel/localization/gnss_blackout.py
+++ b/src/eel/eel/localization/gnss_blackout.py
@@ -1,0 +1,113 @@
+from dataclasses import dataclass
+from typing import Literal, TypedDict
+
+from geopy import distance
+
+GnssTrustState = Literal["trusting", "dead_reckoning", "reacquiring"]
+
+
+class LatLon(TypedDict):
+    lat: float
+    lon: float
+
+
+@dataclass(frozen=True)
+class GnssBlackoutConfig:
+    """Depth-gated GNSS trust with hysteresis and fix clustering on re-entry."""
+
+    enter_depth_m: float
+    exit_depth_m: float
+    cluster_radius_m: float
+    fixes_required: int
+    max_outlier_distance_m: float
+    reacquire_timeout_sec: float
+
+
+DEFAULT_GNSS_BLACKOUT_CONFIG = GnssBlackoutConfig(
+    enter_depth_m=0.35,
+    exit_depth_m=0.15,
+    cluster_radius_m=5.0,
+    fixes_required=2,
+    max_outlier_distance_m=1000.0,
+    reacquire_timeout_sec=30.0,
+)
+
+
+def require_valid_gnss_blackout_config(config: GnssBlackoutConfig) -> GnssBlackoutConfig:
+    if config.enter_depth_m < 0:
+        raise ValueError(f"enter_depth_m must be >= 0, got {config.enter_depth_m}")
+    if config.exit_depth_m < 0:
+        raise ValueError(f"exit_depth_m must be >= 0, got {config.exit_depth_m}")
+    if config.exit_depth_m > config.enter_depth_m:
+        raise ValueError(f"exit_depth_m ({config.exit_depth_m}) must be <= enter_depth_m ({config.enter_depth_m})")
+    if config.cluster_radius_m <= 0:
+        raise ValueError(f"cluster_radius_m must be > 0, got {config.cluster_radius_m}")
+    if config.fixes_required < 1:
+        raise ValueError(f"fixes_required must be >= 1, got {config.fixes_required}")
+    if config.max_outlier_distance_m <= 0:
+        raise ValueError(f"max_outlier_distance_m must be > 0, got {config.max_outlier_distance_m}")
+    if config.reacquire_timeout_sec < 0:
+        raise ValueError(f"reacquire_timeout_sec must be >= 0, got {config.reacquire_timeout_sec}")
+    return config
+
+
+def distance_m_between(a: LatLon, b: LatLon) -> float:
+    return float(
+        distance.distance((a["lat"], a["lon"]), (b["lat"], b["lon"])).meters,
+    )
+
+
+def trust_state_after_depth_change(
+    state: GnssTrustState,
+    depth_m: float,
+    config: GnssBlackoutConfig = DEFAULT_GNSS_BLACKOUT_CONFIG,
+) -> GnssTrustState:
+    if state == "trusting" and depth_m >= config.enter_depth_m:
+        return "dead_reckoning"
+    if state == "dead_reckoning" and depth_m <= config.exit_depth_m:
+        return "reacquiring"
+    if state == "reacquiring" and depth_m >= config.enter_depth_m:
+        return "dead_reckoning"
+    return state
+
+
+def centroid(fixes: list[LatLon]) -> LatLon:
+    return {
+        "lat": sum(fix["lat"] for fix in fixes) / len(fixes),
+        "lon": sum(fix["lon"] for fix in fixes) / len(fixes),
+    }
+
+
+def clustered_fixes(
+    pending_fixes: list[LatLon],
+    config: GnssBlackoutConfig = DEFAULT_GNSS_BLACKOUT_CONFIG,
+) -> LatLon | None:
+    if config.fixes_required < 1:
+        return None
+    if len(pending_fixes) < config.fixes_required:
+        return None
+    recent = pending_fixes[-config.fixes_required :]
+    center = centroid(recent)
+    if all(distance_m_between(center, fix) <= config.cluster_radius_m for fix in recent):
+        return center
+    return None
+
+
+def is_obviously_invalid_fix(
+    fix: LatLon,
+    reference: LatLon,
+    config: GnssBlackoutConfig = DEFAULT_GNSS_BLACKOUT_CONFIG,
+) -> bool:
+    return distance_m_between(fix, reference) > config.max_outlier_distance_m
+
+
+def reacquire_fallback_fix(
+    pending_fixes: list[LatLon],
+    reacquiring_for_sec: float,
+    config: GnssBlackoutConfig = DEFAULT_GNSS_BLACKOUT_CONFIG,
+) -> LatLon | None:
+    if not pending_fixes:
+        return None
+    if reacquiring_for_sec < config.reacquire_timeout_sec:
+        return None
+    return pending_fixes[-1]

--- a/src/eel/eel/localization/localization.py
+++ b/src/eel/eel/localization/localization.py
@@ -8,6 +8,7 @@ from std_msgs.msg import Float32
 
 from eel_interfaces.msg import Coordinate, ImuStatus, PressureStatus
 
+from ..utils.actuator_bounds import is_valid_coordinate
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.sim import LINEAR_VELOCITY
 from ..utils.topics import (
@@ -19,10 +20,31 @@ from ..utils.topics import (
     MOTOR_CMD,
     PRESSURE_STATUS,
 )
+from .gnss_blackout import DEFAULT_GNSS_BLACKOUT_CONFIG, GnssBlackoutConfig, require_valid_gnss_blackout_config
 from .localizer import Localizer
+
+GNSS_BLACKOUT_ENTER_DEPTH_PARAM = "gnss_blackout_enter_depth_m"
+GNSS_BLACKOUT_EXIT_DEPTH_PARAM = "gnss_blackout_exit_depth_m"
+GNSS_REACQUIRE_CLUSTER_RADIUS_PARAM = "gnss_reacquire_cluster_radius_m"
+GNSS_REACQUIRE_FIXES_REQUIRED_PARAM = "gnss_reacquire_fixes_required"
+GNSS_REACQUIRE_MAX_OUTLIER_DISTANCE_PARAM = "gnss_reacquire_max_outlier_distance_m"
+GNSS_REACQUIRE_TIMEOUT_PARAM = "gnss_reacquire_timeout_sec"
 
 FORWARD_MAX_SPEED = LINEAR_VELOCITY
 REVERSE_MAX_SPEED = 0.2 * FORWARD_MAX_SPEED
+
+
+def gnss_blackout_config_from_node(node: Node) -> GnssBlackoutConfig:
+    return require_valid_gnss_blackout_config(
+        GnssBlackoutConfig(
+            enter_depth_m=float(node.get_parameter(GNSS_BLACKOUT_ENTER_DEPTH_PARAM).value),
+            exit_depth_m=float(node.get_parameter(GNSS_BLACKOUT_EXIT_DEPTH_PARAM).value),
+            cluster_radius_m=float(node.get_parameter(GNSS_REACQUIRE_CLUSTER_RADIUS_PARAM).value),
+            fixes_required=int(node.get_parameter(GNSS_REACQUIRE_FIXES_REQUIRED_PARAM).value),
+            max_outlier_distance_m=float(node.get_parameter(GNSS_REACQUIRE_MAX_OUTLIER_DISTANCE_PARAM).value),
+            reacquire_timeout_sec=float(node.get_parameter(GNSS_REACQUIRE_TIMEOUT_PARAM).value),
+        )
+    )
 
 
 def calculate_speed_from_motor_mps(motor_speed: float) -> float:
@@ -36,6 +58,15 @@ def calculate_speed_from_motor_mps(motor_speed: float) -> float:
 class Localization(Node):
     def __init__(self) -> None:
         super().__init__("localization", parameter_overrides=[])
+        self.declare_parameter(GNSS_BLACKOUT_ENTER_DEPTH_PARAM, DEFAULT_GNSS_BLACKOUT_CONFIG.enter_depth_m)
+        self.declare_parameter(GNSS_BLACKOUT_EXIT_DEPTH_PARAM, DEFAULT_GNSS_BLACKOUT_CONFIG.exit_depth_m)
+        self.declare_parameter(GNSS_REACQUIRE_CLUSTER_RADIUS_PARAM, DEFAULT_GNSS_BLACKOUT_CONFIG.cluster_radius_m)
+        self.declare_parameter(GNSS_REACQUIRE_FIXES_REQUIRED_PARAM, DEFAULT_GNSS_BLACKOUT_CONFIG.fixes_required)
+        self.declare_parameter(
+            GNSS_REACQUIRE_MAX_OUTLIER_DISTANCE_PARAM,
+            DEFAULT_GNSS_BLACKOUT_CONFIG.max_outlier_distance_m,
+        )
+        self.declare_parameter(GNSS_REACQUIRE_TIMEOUT_PARAM, DEFAULT_GNSS_BLACKOUT_CONFIG.reacquire_timeout_sec)
         self.update_frequency_hz = 5
         self.gnss_subscription = self.create_subscription(Coordinate, GNSS_STATUS, self.handle_gnss_msg, 10)
         self.motor_subscription = self.create_subscription(Float32, MOTOR_CMD, self.handle_motor_msg, 10)
@@ -54,11 +85,14 @@ class Localization(Node):
         )
         self.status_publisher = self.create_publisher(Coordinate, LOCALIZATION_STATUS, 10)
 
-        self.localizer = Localizer()
+        self.localizer = Localizer(gnss_config=gnss_blackout_config_from_node(self))
         self.loop = self.create_timer(1.0 / self.update_frequency_hz, self.do_work)
         self.get_logger().info(f"Localization node started. {LINEAR_VELOCITY} m/s")
 
     def handle_gnss_msg(self, msg: Coordinate) -> None:
+        if not is_valid_coordinate(msg.lat, msg.lon):
+            self.get_logger().warning(f"Rejecting invalid gnss coordinate lat={msg.lat} lon={msg.lon}")
+            return
         self.current_gnss_status = msg
         self.localizer.update_known_position({"lat": msg.lat, "lon": msg.lon})
 

--- a/src/eel/eel/localization/localizer.py
+++ b/src/eel/eel/localization/localizer.py
@@ -1,27 +1,40 @@
 import time
-from typing import Optional, TypedDict
+from typing import Optional
 
 from geopy import distance
 
+from .gnss_blackout import (
+    DEFAULT_GNSS_BLACKOUT_CONFIG,
+    GnssBlackoutConfig,
+    GnssTrustState,
+    LatLon,
+    clustered_fixes,
+    is_obviously_invalid_fix,
+    reacquire_fallback_fix,
+    trust_state_after_depth_change,
+)
 
-class LatLon(TypedDict):
-    lat: float
-    lon: float
+__all__ = ["LatLon", "Localizer"]
 
 
 class Localizer:
     def __init__(
         self,
-        start_time_sec: float = time.time(),
+        start_time_sec: float | None = None,
+        gnss_config: GnssBlackoutConfig = DEFAULT_GNSS_BLACKOUT_CONFIG,
     ) -> None:
+        self._gnss_config = gnss_config
         self._current_position: Optional[LatLon] = None
-        self._last_recorded_at = start_time_sec
+        self._last_recorded_at = time.time() if start_time_sec is None else start_time_sec
         self._current_speed_mps: float = 0.0
         self._current_heading: float = 0.0
         self._total_meters_traveled: float = 0.0
         self._current_depth: float = 0.0
         self._drift_speed: float = 0.0
         self._drift_bearing: float = 0.0
+        self._gnss_trust_state: GnssTrustState = "trusting"
+        self._pending_gnss_fixes: list[LatLon] = []
+        self._reacquiring_since_sec: Optional[float] = None
 
     def update_speed_mps(self, new_speed_mps: float) -> None:
         self._current_speed_mps = new_speed_mps
@@ -35,16 +48,50 @@ class Localizer:
     def update_drift_bearing(self, new_drift_bearing: float) -> None:
         self._drift_bearing = new_drift_bearing
 
-    def update_known_position(self, new_position: LatLon) -> None:
-        if self._current_depth >= 0.3:
+    def update_known_position(self, new_position: LatLon, now_sec: float | None = None) -> None:
+        now = now_sec if now_sec is not None else time.time()
+        if self._gnss_trust_state == "trusting":
+            self._current_position = new_position
+            self._advance_last_recorded_at(now)
             return
-        self._current_position = new_position
+
+        if self._gnss_trust_state == "dead_reckoning":
+            return
+
+        reference = self._current_position
+        if reference is not None and is_obviously_invalid_fix(new_position, reference, self._gnss_config):
+            return
+
+        self._pending_gnss_fixes.append(new_position)
+        accepted = clustered_fixes(self._pending_gnss_fixes, self._gnss_config)
+        if accepted is None:
+            if self._reacquiring_since_sec is None:
+                reacquiring_for = 0.0
+            else:
+                reacquiring_for = now - self._reacquiring_since_sec
+            accepted = reacquire_fallback_fix(self._pending_gnss_fixes, reacquiring_for, self._gnss_config)
+
+        if accepted is not None:
+            self._accept_gnss_fix(accepted, now)
 
     def get_total_meters_traveled(self) -> float:
         return self._total_meters_traveled
 
-    def update_depth(self, new_depth: float) -> None:
+    def update_depth(self, new_depth: float, now_sec: float | None = None) -> None:
+        previous_state = self._gnss_trust_state
         self._current_depth = new_depth
+        self._gnss_trust_state = trust_state_after_depth_change(
+            self._gnss_trust_state,
+            new_depth,
+            self._gnss_config,
+        )
+        now = now_sec if now_sec is not None else time.time()
+        if self._gnss_trust_state != previous_state and self._gnss_trust_state == "reacquiring":
+            self._pending_gnss_fixes = []
+            self._reacquiring_since_sec = now
+        if self._gnss_trust_state != previous_state and self._gnss_trust_state == "dead_reckoning":
+            self._pending_gnss_fixes = []
+            self._reacquiring_since_sec = None
 
     def get_calculated_position(
         self,
@@ -52,22 +99,35 @@ class Localizer:
     ) -> Optional[LatLon]:
         if self._current_position:
             time_delta = current_time_sec - self._last_recorded_at
+            if time_delta > 0:
+                drift_meters = self._drift_speed * time_delta
 
-            drift_meters = self._drift_speed * time_delta
+                meters_traveled = self._current_speed_mps * time_delta
+                self._total_meters_traveled += meters_traveled
+                new_position = distance.distance(meters=meters_traveled).destination(
+                    (self._current_position["lat"], self._current_position["lon"]),
+                    bearing=self._current_heading,
+                )
 
-            meters_traveled = self._current_speed_mps * time_delta
-            self._total_meters_traveled += meters_traveled
-            new_position = distance.distance(meters=meters_traveled).destination(
-                (self._current_position["lat"], self._current_position["lon"]),
-                bearing=self._current_heading,
-            )
+                final_position = distance.distance(meters=drift_meters).destination(
+                    (new_position.latitude, new_position.longitude), bearing=self._drift_bearing
+                )
 
-            final_position = distance.distance(meters=drift_meters).destination(
-                (new_position.latitude, new_position.longitude), bearing=self._drift_bearing
-            )
+                self._current_position = {
+                    "lat": final_position.latitude,
+                    "lon": final_position.longitude,
+                }
 
-            self._current_position = LatLon(lat=final_position.latitude, lon=final_position.longitude)
-
-        self._last_recorded_at = current_time_sec
+        self._advance_last_recorded_at(current_time_sec)
 
         return self._current_position
+
+    def _accept_gnss_fix(self, position: LatLon, now_sec: float) -> None:
+        self._current_position = position
+        self._advance_last_recorded_at(now_sec)
+        self._pending_gnss_fixes = []
+        self._reacquiring_since_sec = None
+        self._gnss_trust_state = "trusting"
+
+    def _advance_last_recorded_at(self, now_sec: float) -> None:
+        self._last_recorded_at = max(self._last_recorded_at, now_sec)

--- a/src/eel/eel/motor/motor_node.py
+++ b/src/eel/eel/motor/motor_node.py
@@ -6,10 +6,10 @@ import rclpy
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
+from ..utils.actuator_bounds import bounded_unit_cmd
 from ..utils.constants import SIMULATE_PARAM
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import MOTOR_CMD
-from ..utils.utils import clamp
 from .motor_sim import MotorSimulator
 from .motor_watchdog import command_is_stale, require_positive_cmd_timeout
 
@@ -65,7 +65,10 @@ class Motor(Node):
             self._motor_control.close()
 
     def handle_motor_msg(self, msg: Float32) -> None:
-        motor_value = clamp(msg.data, -1, 1)
+        motor_value = bounded_unit_cmd(msg.data)
+        if motor_value is None:
+            self.get_logger().warning(f"Rejecting invalid motor cmd {msg.data}")
+            return
         if motor_value == 0:
             self.stop()
             self._last_cmd_at = None

--- a/src/eel/eel/motor/motor_sim.py
+++ b/src/eel/eel/motor/motor_sim.py
@@ -1,9 +1,14 @@
+from rclpy.logging import get_logger
+
+logger = get_logger(__name__)
+
+
 class MotorSimulator:
     def stop(self) -> None:
-        print("simulating stopping motor")
+        logger.debug("Simulating motor stop")
 
     def forward(self, signal: float) -> None:
-        print("simulating going forward, signal {}".format(signal))
+        logger.debug("Simulating motor forward, signal=%s", signal)
 
     def backward(self, signal: float) -> None:
-        print("simulating going backward, signal {}".format(signal))
+        logger.debug("Simulating motor backward, signal=%s", signal)

--- a/src/eel/eel/mqtt_bridge/inbound_validation.py
+++ b/src/eel/eel/mqtt_bridge/inbound_validation.py
@@ -1,0 +1,136 @@
+import json
+from typing import cast
+
+from ..utils.actuator_bounds import (
+    is_finite_number,
+    is_valid_coordinate,
+    is_valid_depth_target,
+    parse_depth_control_targets,
+)
+from ..utils.pid_tuning import parse_pid_type
+from .payload_types import (
+    AssignmentMqtt,
+    BoolMsgMqtt,
+    CoordinateMqtt,
+    DepthControlCmdMqtt,
+    FloatMsgMqtt,
+    NavigationMissionMqtt,
+    StringMqtt,
+)
+
+
+def _json_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+        return number if is_finite_number(number) else None
+    if isinstance(value, str):
+        try:
+            number = float(value)
+        except ValueError:
+            return None
+        return number if is_finite_number(number) else None
+    return None
+
+
+def parse_float_payload(payload: bytes) -> float | None:
+    try:
+        converted = cast(FloatMsgMqtt, json.loads(payload))
+        return _json_float(converted["data"])
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+
+
+def parse_bool_payload(payload: bytes) -> bool | None:
+    try:
+        converted = cast(BoolMsgMqtt, json.loads(payload))
+        data = converted["data"]
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+    if not isinstance(data, bool):
+        return None
+    return data
+
+
+def parse_string_payload(payload: bytes) -> str | None:
+    try:
+        converted = cast(StringMqtt, json.loads(payload))
+        data = converted["data"]
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+    if not isinstance(data, str) or not data.strip():
+        return None
+    return data.strip()
+
+
+def parse_coordinate_payload(payload: bytes) -> CoordinateMqtt | None:
+    try:
+        converted = cast(CoordinateMqtt, json.loads(payload))
+        lat = _json_float(converted["lat"])
+        lon = _json_float(converted["lon"])
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+    if lat is None or lon is None or not is_valid_coordinate(lat, lon):
+        return None
+    return {"lat": lat, "lon": lon}
+
+
+def parse_depth_control_payload(payload: bytes) -> DepthControlCmdMqtt | None:
+    try:
+        converted = cast(DepthControlCmdMqtt, json.loads(payload))
+        depth_target = _json_float(converted["depth_target"])
+        pitch_target = _json_float(converted["pitch_target"])
+        depth_pid_type = parse_pid_type(converted["depth_pid_type"])
+        pitch_pid_type = parse_pid_type(converted["pitch_pid_type"])
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+    if depth_target is None or pitch_target is None:
+        return None
+    bounded = parse_depth_control_targets(depth_target, pitch_target)
+    if bounded is None:
+        return None
+    depth_target, pitch_target = bounded
+    if depth_pid_type is None or pitch_pid_type is None:
+        return None
+    return {
+        "depth_target": depth_target,
+        "pitch_target": pitch_target,
+        "depth_pid_type": depth_pid_type,
+        "pitch_pid_type": pitch_pid_type,
+    }
+
+
+def parse_mission_payload(payload: bytes) -> NavigationMissionMqtt | None:
+    try:
+        converted = cast(NavigationMissionMqtt, json.loads(payload))
+        assignments = converted["assignments"]
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+    if not isinstance(assignments, list):
+        return None
+
+    parsed: list[AssignmentMqtt] = []
+    for assignment in assignments:
+        try:
+            coord = assignment["coordinate"]
+            lat = _json_float(coord["lat"])
+            lon = _json_float(coord["lon"])
+            target_depth = _json_float(assignment["target_depth"])
+            sync_after = assignment["sync_after"]
+        except (KeyError, TypeError, ValueError):
+            return None
+        if lat is None or lon is None or target_depth is None:
+            return None
+        if not isinstance(sync_after, bool):
+            return None
+        if not is_valid_coordinate(lat, lon) or not is_valid_depth_target(target_depth):
+            return None
+        parsed.append(
+            {
+                "coordinate": {"lat": lat, "lon": lon},
+                "target_depth": target_depth,
+                "sync_after": sync_after,
+            }
+        )
+    return {"assignments": parsed}

--- a/src/eel/eel/mqtt_bridge/node.py
+++ b/src/eel/eel/mqtt_bridge/node.py
@@ -47,19 +47,16 @@ from ..utils.topics import (
     RUDDER_X_CMD,
     RUDDER_Y_CMD,
 )
+from .inbound_validation import (
+    parse_bool_payload,
+    parse_coordinate_payload,
+    parse_depth_control_payload,
+    parse_float_payload,
+    parse_mission_payload,
+    parse_string_payload,
+)
 from .mqtt_sim import LoggingMqttBackend, MqttBackend
-from .types import CoordinateMqtt, to_traced_route_mqtt, transform_coordinate_msg
-
-
-class DepthControlCmdMqtt(TypedDict):
-    depth_target: float
-    pitch_target: float
-    depth_pid_type: str
-    pitch_pid_type: str
-
-
-class StringMqtt(TypedDict):
-    data: str
+from .types import BoolMsgMqtt, CoordinateMqtt, to_traced_route_mqtt, transform_coordinate_msg
 
 
 class ImuStatusMqtt(TypedDict):
@@ -84,30 +81,12 @@ class BatteryStatusMqtt(TypedDict):
     voltage_ratio: float
 
 
-class FloatMsgMqtt(TypedDict):
-    data: float
-
-
-class BoolMsgMqtt(TypedDict):
-    data: bool
-
-
-class AssignmentMqtt(TypedDict):
-    coordinate: CoordinateMqtt
-    target_depth: float
-    sync_after: bool
-
-
 class NavigationStatusMqtt(TypedDict):
     meters_to_target: float
     auto_mode_enabled: bool
     waypoints_left: List[CoordinateMqtt]
     count_goals_left: int
     mission_total_meters: float
-
-
-class NavigationMissionMqtt(TypedDict):
-    assignments: List[AssignmentMqtt]
 
 
 class TankStatusMqtt(TypedDict):
@@ -307,9 +286,12 @@ class MqttBridge(Node):
         retain: bool,
         **_kwargs: object,
     ) -> None:
-        converted = cast(FloatMsgMqtt, json.loads(payload))
+        value = parse_float_payload(payload)
+        if value is None:
+            self.get_logger().warning("Dropping invalid MQTT front tank cmd payload")
+            return
         msg = Float32()
-        msg.data = converted["data"]
+        msg.data = value
         self.front_tank_cmd_publisher.publish(msg)
 
     def handle_incoming_rear_tank_cmd(
@@ -321,9 +303,12 @@ class MqttBridge(Node):
         retain: bool,
         **_kwargs: object,
     ) -> None:
-        converted = cast(FloatMsgMqtt, json.loads(payload))
+        value = parse_float_payload(payload)
+        if value is None:
+            self.get_logger().warning("Dropping invalid MQTT rear tank cmd payload")
+            return
         msg = Float32()
-        msg.data = converted["data"]
+        msg.data = value
         self.rear_tank_cmd_publisher.publish(msg)
 
     def handle_incoming_motor_cmd(
@@ -335,10 +320,12 @@ class MqttBridge(Node):
         retain: bool,
         **_kwargs: object,
     ) -> None:
-        converted = cast(FloatMsgMqtt, json.loads(payload))
-        motor_value = float(converted["data"])
+        value = parse_float_payload(payload)
+        if value is None:
+            self.get_logger().warning("Dropping invalid MQTT motor cmd payload")
+            return
         motor_msg = Float32()
-        motor_msg.data = motor_value
+        motor_msg.data = value
         self.motor_publisher.publish(motor_msg)
 
     def handle_incoming_navigation_cmd(
@@ -350,9 +337,12 @@ class MqttBridge(Node):
         retain: bool,
         **_kwargs: object,
     ) -> None:
-        converted = cast(BoolMsgMqtt, json.loads(payload))
+        value = parse_bool_payload(payload)
+        if value is None:
+            self.get_logger().warning("Dropping invalid MQTT navigation cmd payload")
+            return
         msg = Bool()
-        msg.data = bool(converted["data"])
+        msg.data = value
         self.nav_cmd_publisher.publish(msg)
 
     def handle_incoming_depth_control_cmd(
@@ -364,7 +354,10 @@ class MqttBridge(Node):
         retain: bool,
         **_kwargs: object,
     ) -> None:
-        converted = cast(DepthControlCmdMqtt, json.loads(payload))
+        converted = parse_depth_control_payload(payload)
+        if converted is None:
+            self.get_logger().warning("Dropping invalid MQTT depth control cmd payload")
+            return
         msg = DepthControlCmd()
         msg.depth_pid_type = converted["depth_pid_type"]
         msg.depth_target = converted["depth_target"]
@@ -381,8 +374,10 @@ class MqttBridge(Node):
         retain: bool,
         **_kwargs: object,
     ) -> None:
-        converted = cast(FloatMsgMqtt, json.loads(payload))
-        value = float(converted["data"])
+        value = parse_float_payload(payload)
+        if value is None:
+            self.get_logger().warning("Dropping invalid MQTT rudder x cmd payload")
+            return
         msg = Float32()
         msg.data = value
         self.rudder_horizontal_publisher.publish(msg)
@@ -396,8 +391,10 @@ class MqttBridge(Node):
         retain: bool,
         **_kwargs: object,
     ) -> None:
-        converted = cast(FloatMsgMqtt, json.loads(payload))
-        value = float(converted["data"])
+        value = parse_float_payload(payload)
+        if value is None:
+            self.get_logger().warning("Dropping invalid MQTT rudder y cmd payload")
+            return
         msg = Float32()
         msg.data = value
         self.rudder_vertical_publisher.publish(msg)
@@ -411,17 +408,20 @@ class MqttBridge(Node):
         retain: bool,
         **_kwargs: object,
     ) -> None:
-        converted = cast(NavigationMissionMqtt, json.loads(payload))
+        converted = parse_mission_payload(payload)
+        if converted is None:
+            self.get_logger().warning("Dropping invalid MQTT mission payload")
+            return
         msg = NavigationMission()
         ros_assignments: List[NavigationAssignment] = []
         for assignment in converted["assignments"]:
             ros_assignment = NavigationAssignment()
             coord = Coordinate()
-            coord.lat = float(assignment["coordinate"]["lat"])
-            coord.lon = float(assignment["coordinate"]["lon"])
+            coord.lat = assignment["coordinate"]["lat"]
+            coord.lon = assignment["coordinate"]["lon"]
             ros_assignment.coordinate = coord
-            ros_assignment.sync_after = bool(assignment["sync_after"])
-            ros_assignment.target_depth = float(assignment["target_depth"])
+            ros_assignment.sync_after = assignment["sync_after"]
+            ros_assignment.target_depth = assignment["target_depth"]
             ros_assignments.append(ros_assignment)
         msg.assignments = ros_assignments
         self.mission_publisher.publish(msg)
@@ -435,9 +435,12 @@ class MqttBridge(Node):
         retain: bool,
         **_kwargs: object,
     ) -> None:
-        converted = cast(StringMqtt, json.loads(payload))
+        value = parse_string_payload(payload)
+        if value is None:
+            self.get_logger().warning("Dropping invalid MQTT named mission payload")
+            return
         msg = String()
-        msg.data = converted["data"]
+        msg.data = value
         self.named_mission_publisher.publish(msg)
 
     def handle_incoming_gnss_status(
@@ -449,7 +452,10 @@ class MqttBridge(Node):
         retain: bool,
         **_kwargs: object,
     ) -> None:
-        converted = cast(CoordinateMqtt, json.loads(payload))
+        converted = parse_coordinate_payload(payload)
+        if converted is None:
+            self.get_logger().warning("Dropping invalid MQTT gnss status payload")
+            return
         msg = Coordinate()
         msg.lat = converted["lat"]
         msg.lon = converted["lon"]

--- a/src/eel/eel/mqtt_bridge/payload_types.py
+++ b/src/eel/eel/mqtt_bridge/payload_types.py
@@ -1,0 +1,51 @@
+from typing import List, TypedDict
+
+from ..utils.pid_tuning import PidType
+
+
+class CoordinateMqtt(TypedDict):
+    lat: float
+    lon: float
+
+
+class FloatMsgMqtt(TypedDict):
+    data: float
+
+
+class BoolMsgMqtt(TypedDict):
+    data: bool
+
+
+class StringMqtt(TypedDict):
+    data: str
+
+
+class DepthControlCmdMqtt(TypedDict):
+    depth_target: float
+    pitch_target: float
+    depth_pid_type: PidType
+    pitch_pid_type: PidType
+
+
+class AssignmentMqtt(TypedDict):
+    coordinate: CoordinateMqtt
+    target_depth: float
+    sync_after: bool
+
+
+class NavigationMissionMqtt(TypedDict):
+    assignments: List[AssignmentMqtt]
+
+
+class SubmergedCoordinateMqtt(TypedDict):
+    coordinate: CoordinateMqtt
+    depth: float
+
+
+class TracedRouteMqtt(TypedDict):
+    path: List[SubmergedCoordinateMqtt]
+    started_at: str
+    ended_at: str
+    duration_seconds: float
+    xy_distance_covered_meters: float
+    average_depth_meters: float

--- a/src/eel/eel/mqtt_bridge/types.py
+++ b/src/eel/eel/mqtt_bridge/types.py
@@ -1,29 +1,35 @@
-from typing import List, TypedDict
-
 from eel_interfaces.msg import (
     Coordinate,
     SubmergedCoordinate,
     TracedRoute,
 )
 
+from .payload_types import (
+    AssignmentMqtt,
+    BoolMsgMqtt,
+    CoordinateMqtt,
+    DepthControlCmdMqtt,
+    FloatMsgMqtt,
+    NavigationMissionMqtt,
+    StringMqtt,
+    SubmergedCoordinateMqtt,
+    TracedRouteMqtt,
+)
 
-class CoordinateMqtt(TypedDict):
-    lat: float
-    lon: float
-
-
-class SubmergedCoordinateMqtt(TypedDict):
-    coordinate: CoordinateMqtt
-    depth: float
-
-
-class TracedRouteMqtt(TypedDict):
-    path: List[SubmergedCoordinateMqtt]
-    started_at: str
-    ended_at: str
-    duration_seconds: float
-    xy_distance_covered_meters: float
-    average_depth_meters: float
+__all__ = [
+    "AssignmentMqtt",
+    "BoolMsgMqtt",
+    "CoordinateMqtt",
+    "DepthControlCmdMqtt",
+    "FloatMsgMqtt",
+    "NavigationMissionMqtt",
+    "StringMqtt",
+    "SubmergedCoordinateMqtt",
+    "TracedRouteMqtt",
+    "to_submerged_coord_mqtt",
+    "to_traced_route_mqtt",
+    "transform_coordinate_msg",
+]
 
 
 def transform_coordinate_msg(msg: Coordinate) -> CoordinateMqtt:

--- a/src/eel/eel/navigation/assignments.py
+++ b/src/eel/eel/navigation/assignments.py
@@ -3,6 +3,8 @@ from math import radians, sin
 from time import time
 from typing import Callable, TypedDict
 
+from rclpy.logging import get_logger
+
 from ..utils.nav import get_next_rudder_turn
 from .common import (
     TOLERANCE_IN_METERS,
@@ -10,6 +12,8 @@ from .common import (
     get_2d_distance,
     get_relative_bearing,
 )
+
+logger = get_logger(__name__)
 
 
 def cap_value(value: float, floor: float, ceiling: float) -> float:
@@ -107,8 +111,6 @@ def get_desired_heading_with_cte_correction(
     return desired_heading
 
 
-# TODO: the start_pos should optimally be the start of the route, rather than current position.
-# If there is one, that is. for the first segment, the start_pos has to be current position.
 class WaypointAndDepth(Assignment):
     def __init__(
         self,
@@ -141,7 +143,7 @@ class WaypointAndDepth(Assignment):
         vehicle_pos = (current_position["lat"], current_position["lon"])
         has_passed = has_passed_waypoint(self._prev_wp, self._curr_wp, vehicle_pos)
         if has_passed:
-            print("HAS PASSED WAYPOINT?", has_passed)
+            logger.debug("Passed waypoint between %s and %s", self._prev_wp, self._curr_wp)
 
         if distance_to_target <= TOLERANCE_IN_METERS or has_passed:
             self.is_done = True
@@ -210,7 +212,7 @@ class SurfaceAssignment(Assignment):
             self.seconds_at_surface = 0.0
 
         if self.seconds_at_surface >= 25.0:
-            print("HAS SYNCED FOR X SECONDS. DONE.")
+            logger.debug("Surface sync complete after %.1fs at target", self.seconds_at_surface)
             self.is_done = True
             return {"distance_to_target": distance_to_target}
 
@@ -218,7 +220,7 @@ class SurfaceAssignment(Assignment):
         vehicle_pos = (current_position["lat"], current_position["lon"])
         has_passed = has_passed_waypoint(self._prev_wp, self._curr_wp, vehicle_pos)
         if has_passed:
-            print("HAS PASSED WAYPOINT?", has_passed)
+            logger.debug("Passed waypoint between %s and %s", self._prev_wp, self._curr_wp)
 
         if distance_to_target <= TOLERANCE_IN_METERS or has_passed:
             next_motor = 0.0

--- a/src/eel/eel/navigation/named_missions.py
+++ b/src/eel/eel/navigation/named_missions.py
@@ -1,0 +1,9 @@
+from typing import Literal
+
+NamedMissionName = Literal["rotholmen_runt_2025"]
+
+
+def parse_named_mission(name: str) -> NamedMissionName | None:
+    if name == "rotholmen_runt_2025":
+        return "rotholmen_runt_2025"
+    return None

--- a/src/eel/eel/navigation/navigation_action_client.py
+++ b/src/eel/eel/navigation/navigation_action_client.py
@@ -8,6 +8,7 @@ import rclpy
 from action_msgs.msg import GoalStatus
 from rclpy.action import ActionClient
 from rclpy.action.client import ClientGoalHandle
+from rclpy.logging import get_logger
 from rclpy.node import Node
 from rclpy.task import Future
 from std_msgs.msg import Bool, String
@@ -23,6 +24,7 @@ from eel_interfaces.msg import (
 )
 
 from ..utils.constants import NavigationMissionStatus
+from ..utils.navigation_mission_bounds import is_navigation_mission_valid
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import (
     BATTERY_STATUS,
@@ -35,6 +37,9 @@ from ..utils.topics import (
     PRESSURE_STATUS,
 )
 from .common import get_2d_distance_from_coords
+from .named_missions import parse_named_mission
+
+logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     from rclpy.type_support import GetResultServiceResponse
@@ -153,9 +158,7 @@ def create_surface_goal(next_coordinate: Coordinate, start: Coordinate) -> Navig
     result.start = start
     result.goal = next_coordinate
     result.type = Navigate.Goal.TYPE_SURFACE_SYNC
-    # TODO: I don't think this is used in server?
     result.optional_sync_time = [6.0]
-    # TODO: bad name. since it is not used when surface
     result.next_coordinate_depth = []
     return result
 
@@ -179,7 +182,7 @@ def create_goals(assignments: Sequence[NavigationAssignment], current_position: 
             next = assignments[index + 1]
             result.append(create_surface_goal(next.coordinate, elem.coordinate))
 
-    print("goals", result)
+    logger.debug("Built %d navigation goals from %d assignments", len(result), len(assignments))
 
     return result
 
@@ -274,6 +277,10 @@ class NavigationActionClient(Node):
 
     def set_mission(self, msg: NavigationMission) -> None:
         """Takes a list of coordinates and converts them to a list of navigation goals."""
+        if not is_navigation_mission_valid(msg, max_depth_m=MAX_DEPTH_METERS):
+            self.logger.info("Rejecting invalid navigation mission")
+            return
+
         coordinates: Sequence[NavigationAssignment] = msg.assignments
 
         if len(coordinates) == 0:
@@ -290,11 +297,11 @@ class NavigationActionClient(Node):
         self.logger.info(f"Set mission with {len(self.goals)} goals over {self.mission_total_meters} meters.")
 
     def load_named_mission(self, msg: String) -> None:
-        if msg.data == "rotholmen_runt_2025":
-            mission = create_rotholmen_runt_2025_mission()
-            self.set_mission(mission)
-        else:
-            self.logger.info(f"Unknown mission name {msg.data}")
+        mission_name = parse_named_mission(msg.data)
+        if mission_name == "rotholmen_runt_2025":
+            self.set_mission(create_rotholmen_runt_2025_mission())
+            return
+        self.logger.info(f"Unknown mission name {msg.data}")
 
     def handle_nav_cmd(self, msg: Bool) -> None:
         """Handler for nav cmd messages, either automode or manual as bool."""

--- a/src/eel/eel/navigation/navigation_action_server.py
+++ b/src/eel/eel/navigation/navigation_action_server.py
@@ -210,7 +210,6 @@ class NavigationActionServer(Node):
             self.assignment = self.create_assignment(goal_request)
 
             next_coordinate = goal_request.goal
-            # TODO: print distance to target here.
             self.logger.info(
                 f"Executing new goal, target set to {next_coordinate.lat=} "
                 f"{next_coordinate.lon=}, {self.distance_to_target=}"

--- a/src/eel/eel/pressure/pressure_sensor.py
+++ b/src/eel/eel/pressure/pressure_sensor.py
@@ -1,13 +1,10 @@
-import struct
 import time
-from typing import cast
 
 import serial
 from rclpy.node import Node
 
+from .pressure_serial_frames import FLOAT32_SIZE, take_float32_le
 from .pressure_source import PressureSource
-
-FLOAT_SIZE_IN_BYTES = 4
 
 
 class PressureSensor(PressureSource):
@@ -15,6 +12,7 @@ class PressureSensor(PressureSource):
         self.logger = parent_node.get_logger()
 
         self.serial_connection = serial.Serial(serial_port, timeout=0)
+        self._rx_buffer = b""
 
         self.logger.info(f"{self.serial_connection.in_waiting} bytes in buffer, flushing now.")
 
@@ -31,7 +29,7 @@ class PressureSensor(PressureSource):
         self.logger.info(f"Sensor initialized, fluid density set to 997 kg/m3, offset is {self.atmosphere_offset} m")
 
     def _get_initial_depth(self, retries: int = 10, sleep_time: float = 0.2) -> float | None:
-        for i in range(retries):
+        for _ in range(retries):
             depth = self._get_depth_reading()
             if depth is not None:
                 return depth
@@ -39,25 +37,14 @@ class PressureSensor(PressureSource):
             time.sleep(sleep_time)
         return None
 
-    def _get_depth_as_bytes(self) -> bytes:
-        return self.serial_connection.read(FLOAT_SIZE_IN_BYTES)
-
-    def _get_depth_from_bytes(self, value: bytes) -> float | None:
-        if value:
-            try:
-                stuff = struct.unpack("f", value)
-                depth = cast(float, stuff[0])
-                return depth
-            except struct.error as e:
-                self.logger.info(f"Ignoring depth reading because: {str(e)}")
-                return None
-        return None
-
     def _get_depth_reading(self) -> float | None:
-        depth_as_bytes = self._get_depth_as_bytes()
-        if not depth_as_bytes:
+        waiting = self.serial_connection.in_waiting
+        to_read = waiting if waiting > 0 else FLOAT32_SIZE
+        self._rx_buffer += self.serial_connection.read(to_read)
+        values, self._rx_buffer = take_float32_le(self._rx_buffer)
+        if not values:
             return None
-        return self._get_depth_from_bytes(depth_as_bytes)
+        return values[-1]
 
     def get_current_depth(self) -> float | None:
         depth = self._get_depth_reading()

--- a/src/eel/eel/pressure/pressure_serial_frames.py
+++ b/src/eel/eel/pressure/pressure_serial_frames.py
@@ -1,0 +1,15 @@
+import struct
+
+FLOAT32_SIZE = 4
+
+
+def take_float32_le(buffer: bytes) -> tuple[list[float], bytes]:
+    """Pull complete little-endian float32 frames; return values and leftover bytes."""
+    values: list[float] = []
+    offset = 0
+    while offset + FLOAT32_SIZE <= len(buffer):
+        chunk = buffer[offset : offset + FLOAT32_SIZE]
+        (value,) = struct.unpack("<f", chunk)
+        values.append(value)
+        offset += FLOAT32_SIZE
+    return values, buffer[offset:]

--- a/src/eel/eel/rudder/rudder_node.py
+++ b/src/eel/eel/rudder/rudder_node.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import math
 from enum import Enum
+from time import monotonic
 from typing import Optional
 
 import rclpy
@@ -10,6 +11,8 @@ from std_msgs.msg import Float32
 
 from eel_interfaces.msg import ImuStatus
 
+from ..motor.motor_watchdog import command_is_stale, require_positive_cmd_timeout
+from ..utils.actuator_bounds import bounded_unit_cmd
 from ..utils.constants import SIMULATE_PARAM
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import (
@@ -25,6 +28,10 @@ from ..utils.topics import (
 from ..utils.utils import clamp
 from .actuator.actuator import get_xy_rudder
 from .actuator.types import Vector2d
+
+RUDDER_CMD_TIMEOUT_PARAM = "cmd_timeout_s"
+DEFAULT_RUDDER_CMD_TIMEOUT_S = 1.0
+WATCHDOG_CHECK_PERIOD_S = 0.2
 
 
 class Rudders(Enum):
@@ -46,7 +53,9 @@ class Rudder(Node):
         super().__init__("rudder_node")
 
         self.declare_parameter(SIMULATE_PARAM, False)
+        self.declare_parameter(RUDDER_CMD_TIMEOUT_PARAM, DEFAULT_RUDDER_CMD_TIMEOUT_S)
         self.should_simulate = bool(self.get_parameter(SIMULATE_PARAM).value)
+        self.cmd_timeout_s = require_positive_cmd_timeout(float(self.get_parameter(RUDDER_CMD_TIMEOUT_PARAM).value))
         self.logger = self.get_logger()
 
         pigpiod_host_parameter = "pigpiod_host"
@@ -65,13 +74,21 @@ class Rudder(Node):
 
         self.current_x_cmd: float = float()
         self.current_y_cmd: float = float()
+        self._last_cmd_at: float | None = None
 
         self.current_roll = 0.0
         self.current_rudder_status: Vector2d = {"x": 0.0, "y": 0.0}
 
         self.xy_rudder = get_xy_rudder({"simulate": self.should_simulate, "pigpiod_host": self.pigpiod_host})
 
-        self.logger.info("{}Rudder node started.".format("SIMULATE " if self.should_simulate else ""))
+        self.create_timer(WATCHDOG_CHECK_PERIOD_S, self._watchdog_tick)
+
+        self.logger.info(
+            "{}Rudder node started (cmd_timeout_s={}).".format(
+                "SIMULATE " if self.should_simulate else "",
+                self.cmd_timeout_s,
+            )
+        )
 
         # Send the initial offset values for rudder x and y for front end to pick up
         self.publish_rudder_offset_value(Rudders.RUDDER_X)
@@ -85,7 +102,12 @@ class Rudder(Node):
         self.merge_and_handle_commands()
 
     def handle_x_cmd(self, msg: Float32) -> None:
-        self.current_x_cmd = msg.data
+        bounded = bounded_unit_cmd(msg.data)
+        if bounded is None:
+            self.logger.warning(f"Rejecting invalid rudder x cmd {msg.data}")
+            return
+        self.current_x_cmd = bounded
+        self._refresh_cmd_watchdog()
         self.merge_and_handle_commands()
 
     def publish_rudder_offset_value(self, rudder_type: Rudders) -> None:
@@ -120,7 +142,27 @@ class Rudder(Node):
         pass
 
     def handle_y_cmd(self, msg: Float32) -> None:
-        self.current_y_cmd = msg.data
+        bounded = bounded_unit_cmd(msg.data)
+        if bounded is None:
+            self.logger.warning(f"Rejecting invalid rudder y cmd {msg.data}")
+            return
+        self.current_y_cmd = bounded
+        self._refresh_cmd_watchdog()
+        self.merge_and_handle_commands()
+
+    def _refresh_cmd_watchdog(self) -> None:
+        if self.current_x_cmd == 0 and self.current_y_cmd == 0:
+            self._last_cmd_at = None
+            return
+        self._last_cmd_at = monotonic()
+
+    def _watchdog_tick(self) -> None:
+        if not command_is_stale(self._last_cmd_at, monotonic(), self.cmd_timeout_s):
+            return
+        self.logger.warning("rudder cmd stale; centering rudder")
+        self.current_x_cmd = 0.0
+        self.current_y_cmd = 0.0
+        self._last_cmd_at = None
         self.merge_and_handle_commands()
 
     def handle_y_offset(self, msg: Float32) -> None:

--- a/src/eel/eel/tank/tank_node.py
+++ b/src/eel/eel/tank/tank_node.py
@@ -8,6 +8,7 @@ from std_msgs.msg import Float32
 
 from eel_interfaces.msg import TankStatus
 
+from ..utils.actuator_bounds import bounded_tank_level
 from ..utils.constants import (
     CMD_TOPIC_PARAM,
     DIRECTION_PIN_PARAM,
@@ -21,14 +22,14 @@ from ..utils.constants import (
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.pid_controller import PidController
 from ..utils.utils import clamp
+from .tank_target import (
+    DEFAULT_TANK_TARGET_CONFIG,
+    RunningAverage,
+    tank_stop_reason,
+)
 from .tank_utils.create_tank import create_tank
 
 TANK_FILL_TIME_S = 22
-# change depending on how big of an error we accept
-TARGET_TOLERANCE = 0.02
-
-LEVEL_FLOOR = 0.0
-LEVEL_CEILING = 1.0
 
 # TANK_RANGE_MM = TANK_CEILING_MM - TANK_FLOOR_MM
 # TANK_FILL_VELOCITY_MMPS = TANK_RANGE_MM / TANK_FILL_TIME_S
@@ -51,51 +52,7 @@ UPDATE_FREQUENCY = 10
 
 TANK_CALIBRATION_UNSET = float("nan")
 
-
 TargetStatus = Literal["target_reached", "ceiling_reached", "floor_reached", "no_target", "adjusting"]
-
-
-# TODO:
-# '<=' not supported between instances of 'float' and 'NoneType'
-def is_within_accepted_target_boundaries(current_level: Optional[float], target_level: Optional[float]) -> bool:
-    if current_level is None or target_level is None:
-        return False
-    low_threshold = target_level - (TARGET_TOLERANCE / 2)
-    high_threshold = target_level + (TARGET_TOLERANCE / 2)
-    is_within_target = low_threshold <= current_level <= high_threshold
-    return is_within_target
-
-
-def is_above_target(current_level: float, target_level: float) -> bool:
-    high_threshold = target_level + (TARGET_TOLERANCE / 2)
-    return current_level > high_threshold
-
-
-def is_below_target(current_level: float, target_level: float) -> bool:
-    low_threshold = target_level - (TARGET_TOLERANCE / 2)
-    return current_level < low_threshold
-
-
-def is_at_floor(current_level: float) -> bool:
-    return current_level <= (LEVEL_FLOOR + TARGET_TOLERANCE)
-
-
-def is_at_ceiling(current_level: float) -> bool:
-    return current_level >= (LEVEL_CEILING - TARGET_TOLERANCE)
-
-
-def get_level_velocity(
-    level: float,
-    previous_level: Optional[float],
-    now: float,
-    previous_level_at: Optional[float],
-) -> float:
-    if previous_level is None or previous_level_at is None:
-        return 0.0
-    level_delta = level - previous_level
-    time_delta = now - previous_level_at
-    velocity = level_delta / time_delta
-    return velocity
 
 
 # NOTE: example usage
@@ -110,20 +67,6 @@ def get_level_velocity(
 # ros2 run eel tank --ros-args -p simulate:=False -p cmd_topic:=/tank_front/cmd \
 #   -p status_topic:=/tank_front/status -p motor_pin:=23 -p direction_pin:=18 \
 #   -p tank_floor_value:=4736 -p tank_ceiling_value:=18256 -p distance_sensor_channel:=1
-
-
-class RunningAverage:
-    def __init__(self, size: int) -> None:
-        self.size = size
-        self.samples = [0.0] * size
-        self.index = 0
-
-    def add_sample(self, value: float) -> None:
-        self.samples[self.index] = value
-        self.index = (self.index + 1) % self.size
-
-    def get_average(self) -> float:
-        return sum(self.samples) / self.size
 
 
 class TankNode(Node):
@@ -157,13 +100,6 @@ class TankNode(Node):
         self.target_status: TargetStatus = "no_target"
 
         self.current_level: Optional[float] = None
-        self.current_velocity: float = float()
-        self.previous_level: Optional[float] = None
-        self.previous_level_at: Optional[float] = None
-
-        self.sample_index = 0
-        self.sample_size = 10
-        self.level_samples = [0.0 for _ in range(self.sample_size)]
 
         self.clamp_value = 0.0
         self.clamp_max_value = 1.0
@@ -177,7 +113,7 @@ class TankNode(Node):
         # GUNNAR
         # self.tank_motor_pid = PidController(0.0, kP=2.0, kI=0.1, kD=0.75)
         # self.tank_motor_pid = PidController(0.0, kP=4.0, kI=0.2, kD=1.2)
-        self.tank_motor_pid = PidController(0.0, kP=8.0, kI=0.5, kD=2.5)
+        self.tank_motor_pid = PidController(0.0, kP=8.0, kI=0.5, kD=2.5, output_min=-1.0, output_max=1.0)
 
         # DAVID
         # self.tank_motor_pid = PidController(0.0, kP=1.0, kI=0.2, kD=0.75)
@@ -230,8 +166,16 @@ class TankNode(Node):
         self.is_autocorrecting = False
 
     def handle_tank_cmd(self, msg: Float32) -> None:
-        requested_target_level = msg.data
-        target_level = clamp(requested_target_level, LEVEL_FLOOR, LEVEL_CEILING)
+        bounded_level = bounded_tank_level(msg.data)
+        if bounded_level is None:
+            self.get_logger().warning(f"Rejecting invalid tank target level {msg.data}")
+            return
+        requested_target_level = bounded_level
+        target_level = clamp(
+            requested_target_level,
+            DEFAULT_TANK_TARGET_CONFIG.level_floor,
+            DEFAULT_TANK_TARGET_CONFIG.level_ceiling,
+        )
 
         self.target_status = "adjusting"
         self.target_level = target_level
@@ -266,32 +210,22 @@ class TankNode(Node):
 
         level_average = self.running_average.get_average()
 
-        # TODO: maybe publish both average and momentary level
         self.publish_status(self.current_level)
 
         if self.target_level is None:
             return
 
-        if is_at_floor(level_average) and self.target_level <= level_average:
+        stop_reason = tank_stop_reason(level_average, self.target_level)
+        if stop_reason is not None:
             self.tank.stop()
             self.tank_motor_pid.reset_cumulative_error()
-            self.target_status = "floor_reached"
-        elif is_at_ceiling(level_average) and self.target_level >= level_average:
-            self.tank.stop()
-            self.tank_motor_pid.reset_cumulative_error()
-            self.target_status = "ceiling_reached"
-        elif is_within_accepted_target_boundaries(level_average, self.target_level):
-            self.tank.stop()
-            self.tank_motor_pid.reset_cumulative_error()
-            self.target_status = "target_reached"
+            self.target_status = stop_reason
         else:
-            if self.clamp_value <= self.clamp_max_value:
-                self.clamp_value += 0.05
+            if self.clamp_value < self.clamp_max_value:
+                self.clamp_value = min(self.clamp_value + 0.05, self.clamp_max_value)
+            self.tank_motor_pid.update_output_limits(-self.clamp_value, self.clamp_value)
             pid_value = self.tank_motor_pid.compute(level_average)
-            if abs(pid_value) > 1.0:
-                self.tank_motor_pid.reset_cumulative_error()
-
-            next_value = clamp(pid_value, -self.clamp_value, self.clamp_value)
+            next_value = pid_value
 
             # Debounce log: only log once every 10 cycles
             self._next_value_log_counter += 1

--- a/src/eel/eel/tank/tank_target.py
+++ b/src/eel/eel/tank/tank_target.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+TankStopReason = Literal["floor_reached", "ceiling_reached", "target_reached"]
+
+
+@dataclass(frozen=True)
+class TankTargetConfig:
+    """Normalized tank level range and stop margins.
+
+    edge_margin: how close to floor/ceiling counts as "at the limit"
+    target_half_band: ± band around target that counts as "close enough"
+    """
+
+    level_floor: float
+    level_ceiling: float
+    edge_margin: float
+    target_half_band: float
+
+
+DEFAULT_TANK_TARGET_CONFIG = TankTargetConfig(
+    level_floor=0.0,
+    level_ceiling=1.0,
+    edge_margin=0.02,
+    target_half_band=0.01,
+)
+
+
+def is_within_accepted_target_boundaries(
+    current_level: Optional[float],
+    target_level: Optional[float],
+    config: TankTargetConfig = DEFAULT_TANK_TARGET_CONFIG,
+) -> bool:
+    if current_level is None or target_level is None:
+        return False
+    half_band = config.target_half_band
+    return (target_level - half_band) <= current_level <= (target_level + half_band)
+
+
+def is_at_floor(current_level: float, config: TankTargetConfig = DEFAULT_TANK_TARGET_CONFIG) -> bool:
+    return current_level <= (config.level_floor + config.edge_margin)
+
+
+def is_at_ceiling(current_level: float, config: TankTargetConfig = DEFAULT_TANK_TARGET_CONFIG) -> bool:
+    return current_level >= (config.level_ceiling - config.edge_margin)
+
+
+def tank_stop_reason(
+    level_average: float,
+    target_level: float,
+    config: TankTargetConfig = DEFAULT_TANK_TARGET_CONFIG,
+) -> TankStopReason | None:
+    if is_at_floor(level_average, config) and target_level <= level_average:
+        return "floor_reached"
+    if is_at_ceiling(level_average, config) and target_level >= level_average:
+        return "ceiling_reached"
+    if is_within_accepted_target_boundaries(level_average, target_level, config):
+        return "target_reached"
+    return None
+
+
+class RunningAverage:
+    def __init__(self, size: int) -> None:
+        if size < 1:
+            raise ValueError("RunningAverage size must be at least 1")
+        self.size = size
+        self.samples = [0.0] * size
+        self.index = 0
+
+    def add_sample(self, value: float) -> None:
+        self.samples[self.index] = value
+        self.index = (self.index + 1) % self.size
+
+    def get_average(self) -> float:
+        return sum(self.samples) / self.size

--- a/src/eel/eel/utils/actuator_bounds.py
+++ b/src/eel/eel/utils/actuator_bounds.py
@@ -1,0 +1,62 @@
+import math
+
+from .utils import clamp
+
+MOTOR_CMD_MIN = -1.0
+MOTOR_CMD_MAX = 1.0
+TANK_LEVEL_MIN = 0.0
+TANK_LEVEL_MAX = 1.0
+MAX_DEPTH_M = 3.0
+MAX_PITCH_DEG = 45.0
+LAT_MIN = -90.0
+LAT_MAX = 90.0
+LON_MIN = -180.0
+LON_MAX = 180.0
+
+
+def is_finite_number(value: float) -> bool:
+    return math.isfinite(value)
+
+
+def bounded_unit_cmd(value: float) -> float | None:
+    if not is_finite_number(value):
+        return None
+    return clamp(value, MOTOR_CMD_MIN, MOTOR_CMD_MAX)
+
+
+def bounded_tank_level(value: float) -> float | None:
+    if not is_finite_number(value):
+        return None
+    return clamp(value, TANK_LEVEL_MIN, TANK_LEVEL_MAX)
+
+
+def is_valid_depth_target(value: float, max_depth_m: float = MAX_DEPTH_M) -> bool:
+    if not is_finite_number(value):
+        return False
+    return 0.0 <= value <= max_depth_m
+
+
+def bounded_depth_target(value: float, max_depth_m: float = MAX_DEPTH_M) -> float | None:
+    if not is_finite_number(value):
+        return None
+    return clamp(value, 0.0, max_depth_m)
+
+
+def bounded_pitch_target(value: float, max_pitch_deg: float = MAX_PITCH_DEG) -> float | None:
+    if not is_finite_number(value):
+        return None
+    return clamp(value, -max_pitch_deg, max_pitch_deg)
+
+
+def parse_depth_control_targets(depth_target: float, pitch_target: float) -> tuple[float, float] | None:
+    depth = bounded_depth_target(depth_target)
+    pitch = bounded_pitch_target(pitch_target)
+    if depth is None or pitch is None:
+        return None
+    return depth, pitch
+
+
+def is_valid_coordinate(lat: float, lon: float) -> bool:
+    if not is_finite_number(lat) or not is_finite_number(lon):
+        return False
+    return LAT_MIN <= lat <= LAT_MAX and LON_MIN <= lon <= LON_MAX

--- a/src/eel/eel/utils/mission_bounds.py
+++ b/src/eel/eel/utils/mission_bounds.py
@@ -1,0 +1,21 @@
+from .actuator_bounds import MAX_DEPTH_M, is_valid_coordinate, is_valid_depth_target
+
+
+def is_mission_waypoint_valid(
+    lat: float,
+    lon: float,
+    target_depth: float,
+    max_depth_m: float = MAX_DEPTH_M,
+) -> bool:
+    if not is_valid_coordinate(lat, lon):
+        return False
+    return is_valid_depth_target(target_depth, max_depth_m)
+
+
+def are_mission_waypoints_valid(
+    waypoints: list[tuple[float, float, float]],
+    max_depth_m: float = MAX_DEPTH_M,
+) -> bool:
+    if len(waypoints) == 0:
+        return True
+    return all(is_mission_waypoint_valid(lat, lon, depth, max_depth_m) for lat, lon, depth in waypoints)

--- a/src/eel/eel/utils/navigation_mission_bounds.py
+++ b/src/eel/eel/utils/navigation_mission_bounds.py
@@ -1,0 +1,15 @@
+from eel_interfaces.msg import NavigationAssignment, NavigationMission
+
+from .actuator_bounds import MAX_DEPTH_M
+from .mission_bounds import is_mission_waypoint_valid
+
+
+def is_mission_assignment_valid(assignment: NavigationAssignment, max_depth_m: float = MAX_DEPTH_M) -> bool:
+    coord = assignment.coordinate
+    return is_mission_waypoint_valid(coord.lat, coord.lon, assignment.target_depth, max_depth_m)
+
+
+def is_navigation_mission_valid(msg: NavigationMission, max_depth_m: float = MAX_DEPTH_M) -> bool:
+    if len(msg.assignments) == 0:
+        return True
+    return all(is_mission_assignment_valid(assignment, max_depth_m) for assignment in msg.assignments)

--- a/src/eel/eel/utils/pid_controller.py
+++ b/src/eel/eel/utils/pid_controller.py
@@ -1,5 +1,62 @@
-from time import time
+from dataclasses import dataclass
+from time import monotonic
 from typing import Callable, Optional
+
+
+@dataclass
+class PidState:
+    cumulative_error: float = 0.0
+    last_error: float = 0.0
+
+
+@dataclass(frozen=True)
+class PidGains:
+    kP: float
+    kI: float
+    kD: float
+
+
+@dataclass(frozen=True)
+class OutputLimits:
+    min: float
+    max: float
+
+
+def clamp_output(value: float, limits: OutputLimits | None) -> float:
+    if limits is None:
+        return value
+    return max(limits.min, min(limits.max, value))
+
+
+def _validate_output_limits(output_min: float, output_max: float) -> None:
+    if output_min > output_max:
+        raise ValueError(f"output_min ({output_min}) must be <= output_max ({output_max})")
+
+
+def pid_step(
+    state: PidState,
+    measured: float,
+    setpoint: float,
+    gains: PidGains,
+    dt: float,
+    limits: OutputLimits | None = None,
+) -> tuple[float, PidState]:
+    error = setpoint - measured
+
+    cumulative_error = state.cumulative_error + error * dt
+    p = gains.kP * error
+    i = cumulative_error * gains.kI
+
+    rate_of_error = (error - state.last_error) / dt if dt > 0 else 0.0
+    d = rate_of_error * gains.kD
+
+    raw = p + i + d
+    output = clamp_output(raw, limits)
+
+    if limits is not None and output != raw and gains.kI != 0 and dt > 0:
+        cumulative_error += (output - raw) / gains.kI
+
+    return output, PidState(cumulative_error=cumulative_error, last_error=error)
 
 
 class PidController:
@@ -9,52 +66,59 @@ class PidController:
         kP: float = 0.0,
         kI: float = 0.0,
         kD: float = 0.0,
+        output_min: float | None = None,
+        output_max: float | None = None,
         on_log_error: Optional[Callable[[float], None]] = None,
     ) -> None:
-        self.kP = kP  # proportional gain
-        self.kI = kI  # integral gain
-        self.kD = kD  # derivative gain
+        self.kP = kP
+        self.kI = kI
+        self.kD = kD
         self.set_point = set_point
-        self.last_computed_at: Optional[float] = None
-        self.cumulative_error = 0.0
-        self.last_error = 0.0
+        if output_min is not None and output_max is not None:
+            _validate_output_limits(output_min, output_max)
+        self.output_min = output_min
+        self.output_max = output_max
         self.on_log_error = on_log_error
+        self._state = PidState()
+        self._last_computed_at: float | None = None
 
     def update_set_point(self, value: float) -> None:
         self.set_point = value
 
+    def update_output_limits(self, output_min: float, output_max: float) -> None:
+        _validate_output_limits(output_min, output_max)
+        self.output_min = output_min
+        self.output_max = output_max
+
     def reset_cumulative_error(self) -> None:
-        self.cumulative_error = 0
+        self._state.cumulative_error = 0.0
 
-    def compute(self, system_current_value: float) -> float:
-        now = time()
+    def _output_limits(self) -> OutputLimits | None:
+        if self.output_min is None or self.output_max is None:
+            return None
+        return OutputLimits(self.output_min, self.output_max)
 
-        if self.last_computed_at is None:
-            self.last_computed_at = now
+    def compute(self, system_current_value: float, now: float | None = None) -> float:
+        if now is None:
+            now = monotonic()
+
+        if self._last_computed_at is None:
+            self._last_computed_at = now
+            dt = 0.0
+        else:
+            dt = now - self._last_computed_at
+            self._last_computed_at = now
 
         error = self.set_point - system_current_value
-
         if self.on_log_error:
             self.on_log_error(error)
 
-        p = self.kP * error
-
-        time_delta = now - self.last_computed_at
-        self.cumulative_error += error * time_delta
-
-        i = self.cumulative_error * self.kI
-
-        error_delta = error - self.last_error
-
-        rate_of_error = 0.0
-
-        if time_delta > 0:
-            rate_of_error = error_delta / time_delta
-
-        d = rate_of_error * self.kD
-
-        self.last_error = error
-
-        self.last_computed_at = now
-
-        return p + i + d
+        output, self._state = pid_step(
+            self._state,
+            system_current_value,
+            self.set_point,
+            PidGains(self.kP, self.kI, self.kD),
+            dt,
+            self._output_limits(),
+        )
+        return output

--- a/src/eel/eel/utils/pid_tuning.py
+++ b/src/eel/eel/utils/pid_tuning.py
@@ -63,6 +63,36 @@
 
 # Kp 0.08000000000000002 Ki 0 Kd 0.12700000000000003
 
+from typing import Literal, cast
+
+PidType = Literal[
+    "classic_PID",
+    "P",
+    "PI",
+    "PD",
+    "pessen_integration",
+    "some_overshoot",
+    "no_overshoot",
+]
+
+VALID_PID_TYPES: frozenset[str] = frozenset(
+    (
+        "classic_PID",
+        "P",
+        "PI",
+        "PD",
+        "pessen_integration",
+        "some_overshoot",
+        "no_overshoot",
+    )
+)
+
+
+def parse_pid_type(value: object) -> PidType | None:
+    if not isinstance(value, str) or value not in VALID_PID_TYPES:
+        return None
+    return cast(PidType, value)
+
 
 def get_simulation_pid_settings() -> tuple[float, float, float, float]:
     depth_Ku = 8.0
@@ -88,7 +118,7 @@ def get_Kd(Kp: float, Td: float) -> float:
     return Kp * Td
 
 
-def lookup_zieglernichols_gains(Ku: float, Tu: float, pid_type: str) -> tuple[float, float, float]:
+def lookup_zieglernichols_gains(Ku: float, Tu: float, pid_type: PidType) -> tuple[float, float, float]:
     if pid_type == "classic_PID":
         Kp = 0.6 * Ku
         Ti = Tu / 2

--- a/src/eel/eel/utils/serial_helpers.py
+++ b/src/eel/eel/utils/serial_helpers.py
@@ -3,8 +3,11 @@ import time
 from typing import Callable, Optional
 
 import serial
+from rclpy.logging import get_logger
 
 SLEEP_TIME = 0.01
+
+logger = get_logger(__name__)
 
 
 class SerialReaderWriter:
@@ -26,20 +29,10 @@ class SerialReaderWriter:
     def send(self, message: str) -> None:
         self._write_one_message(message)
 
-    # TODO: remove or use? it could be interesting to see if there's ever anything in in_waiting or out_waiting
-    # def _flush_if_necessary(self):
-    #     in_waiting = self._ser.in_waiting
-    #     out_waiting = self._ser.out_waiting
-    #     if in_waiting > 0 or out_waiting > 0:
-    #         print("in_waiting", in_waiting, "out_waiting", out_waiting)
-    #         self._ser.flush()
-
     def _write_one_message(self, message: str) -> None:
         msg_line = "{}\n".format(message)
         self._ser.write(bytes(msg_line, "utf-8"))
         self._ser.flush()
-        # TODO: remove or use?
-        # self._flush_if_necessary()
 
     def _loop(self) -> None:
         while True:
@@ -48,9 +41,7 @@ class SerialReaderWriter:
                 try:
                     self._on_message(msg.decode("utf-8").strip())
                 except UnicodeDecodeError:
-                    print("Unicode decode error. Ignoring", msg)
+                    logger.warning("Unicode decode error, ignoring serial line: %r", msg)
 
             self._ser.flush()
-            # TODO: remove or use?
-            # self._flush_if_necessary()
             time.sleep(SLEEP_TIME)

--- a/src/eel/test/eel/localization/gnss_blackout_test.py
+++ b/src/eel/test/eel/localization/gnss_blackout_test.py
@@ -1,0 +1,87 @@
+from eel.localization.gnss_blackout import (
+    GnssBlackoutConfig,
+    clustered_fixes,
+    require_valid_gnss_blackout_config,
+    trust_state_after_depth_change,
+)
+
+TEST_CONFIG = GnssBlackoutConfig(
+    enter_depth_m=0.35,
+    exit_depth_m=0.15,
+    cluster_radius_m=10.0,
+    fixes_required=2,
+    max_outlier_distance_m=1000.0,
+    reacquire_timeout_sec=30.0,
+)
+
+
+def test__when_shallow__should_trust_gnss() -> None:
+    assert trust_state_after_depth_change("trusting", 0.10, TEST_CONFIG) == "trusting"
+
+
+def test__when_deep_enough__should_enter_dead_reckoning() -> None:
+    assert trust_state_after_depth_change("trusting", 0.35, TEST_CONFIG) == "dead_reckoning"
+
+
+def test__when_surfacing__should_enter_reacquiring() -> None:
+    assert trust_state_after_depth_change("dead_reckoning", 0.15, TEST_CONFIG) == "reacquiring"
+
+
+def test__when_resubmerging_during_reacquire__should_return_to_dead_reckoning() -> None:
+    assert trust_state_after_depth_change("reacquiring", 0.35, TEST_CONFIG) == "dead_reckoning"
+
+
+def test__when_two_fixes_agree__should_return_cluster_centroid() -> None:
+    fixes = [{"lat": 0.0, "lon": 0.0}, {"lat": 0.0, "lon": 0.0000001}]
+    accepted = clustered_fixes(fixes, TEST_CONFIG)
+    assert accepted is not None
+    assert accepted["lat"] == 0.0
+
+
+def test__when_fixes_disagree__should_not_cluster() -> None:
+    fixes = [{"lat": 0.0, "lon": 0.0}, {"lat": 1.0, "lon": 1.0}]
+    assert clustered_fixes(fixes, TEST_CONFIG) is None
+
+
+def test__when_fixes_required_is_zero__should_not_cluster() -> None:
+    invalid_config = GnssBlackoutConfig(
+        enter_depth_m=0.35,
+        exit_depth_m=0.15,
+        cluster_radius_m=10.0,
+        fixes_required=0,
+        max_outlier_distance_m=1000.0,
+        reacquire_timeout_sec=30.0,
+    )
+    assert clustered_fixes([{"lat": 0.0, "lon": 0.0}], invalid_config) is None
+
+
+def test__when_exit_depth_exceeds_enter_depth__should_raise() -> None:
+    config = GnssBlackoutConfig(
+        enter_depth_m=0.15,
+        exit_depth_m=0.35,
+        cluster_radius_m=5.0,
+        fixes_required=2,
+        max_outlier_distance_m=1000.0,
+        reacquire_timeout_sec=30.0,
+    )
+    try:
+        require_valid_gnss_blackout_config(config)
+        raise AssertionError("expected ValueError")
+    except ValueError:
+        pass
+
+
+def test__when_reacquire_timeout_is_negative__should_raise() -> None:
+    config = GnssBlackoutConfig(
+        enter_depth_m=0.35,
+        exit_depth_m=0.15,
+        cluster_radius_m=5.0,
+        fixes_required=2,
+        max_outlier_distance_m=1000.0,
+        reacquire_timeout_sec=-1.0,
+    )
+    try:
+        require_valid_gnss_blackout_config(config)
+        raise AssertionError("expected ValueError")
+    except ValueError:
+        pass

--- a/src/eel/test/eel/localization/localizer_test.py
+++ b/src/eel/test/eel/localization/localizer_test.py
@@ -1,6 +1,7 @@
 import math
 import time
 
+from eel.localization.gnss_blackout import GnssBlackoutConfig
 from eel.localization.localizer import LatLon, Localizer
 
 
@@ -50,7 +51,7 @@ def test__when_speed_zero__should_not_travel_any_distance() -> None:
 
 def test__when_speed_1_mps__should_travel_1_m_after_1_second() -> None:
     instance_to_test = Localizer(start_time_sec=0)
-    instance_to_test.update_known_position({"lat": 0, "lon": 0})
+    instance_to_test.update_known_position({"lat": 0, "lon": 0}, now_sec=0.0)
     instance_to_test.update_speed_mps(1.0)
     instance_to_test.get_calculated_position(1)
     assert instance_to_test.get_total_meters_traveled() == 1.0
@@ -58,7 +59,7 @@ def test__when_speed_1_mps__should_travel_1_m_after_1_second() -> None:
 
 def test__when_speed_1_mps_and_heading_zero__should_keep_same_lon() -> None:
     instance_to_test = Localizer(start_time_sec=0)
-    instance_to_test.update_known_position({"lat": 20, "lon": 10})
+    instance_to_test.update_known_position({"lat": 20, "lon": 10}, now_sec=0.0)
     instance_to_test.update_speed_mps(1.0)
     actual = instance_to_test.get_calculated_position(100.0)
     assert actual and actual["lon"] == 10
@@ -66,10 +67,10 @@ def test__when_speed_1_mps_and_heading_zero__should_keep_same_lon() -> None:
 
 def test__when_speed_1_mps_and_heading_zero__lat_should_be_slightly_bigger() -> None:
     instance_to_test = Localizer(start_time_sec=0)
-    instance_to_test.update_known_position({"lat": 0, "lon": 10})
+    instance_to_test.update_known_position({"lat": 0, "lon": 10}, now_sec=0.0)
     instance_to_test.update_speed_mps(1.0)
     actual = instance_to_test.get_calculated_position(1.0)
-    assert actual and 9.043695e-06 > actual["lat"] > 9.043693e-060
+    assert actual and 9.043695e-06 > actual["lat"] > 9.043693e-06
 
 
 def test__when_speed_1_mps_and_heading_90__should_keep_same_lat() -> None:
@@ -84,7 +85,7 @@ def test__when_speed_1_mps_and_heading_90__should_keep_same_lat() -> None:
 def test__when_speed_1_mps_and_heading_45__lat_and_lon_should_be_slightly_bigger() -> None:
     instance_to_test = Localizer(start_time_sec=0)
     instance_to_test.get_calculated_position(0)
-    instance_to_test.update_known_position({"lat": 0, "lon": 0})
+    instance_to_test.update_known_position({"lat": 0, "lon": 0}, now_sec=0.0)
     instance_to_test.update_speed_mps(1.0)
     instance_to_test.update_heading(45)
 
@@ -95,7 +96,7 @@ def test__when_speed_1_mps_and_heading_45__lat_and_lon_should_be_slightly_bigger
 
 def test__when_speed_1mps_and_heading_45_and_100s_travel__should_move_a_fair_bit() -> None:
     instance_to_test = Localizer(start_time_sec=0)
-    instance_to_test.update_known_position({"lat": 0, "lon": 0})
+    instance_to_test.update_known_position({"lat": 0, "lon": 0}, now_sec=0.0)
     instance_to_test.update_speed_mps(1.0)
     instance_to_test.update_heading(45)
     actual = instance_to_test.get_calculated_position(100.0)
@@ -106,7 +107,7 @@ def test__when_speed_1mps_and_heading_45_and_100s_travel__should_move_a_fair_bit
 def test__when_one_known_and_sequence_of_moves__should_move_as_specified() -> None:
     current_time = time.time()
     instance_to_test = Localizer(start_time_sec=current_time)
-    instance_to_test.update_known_position({"lat": 0, "lon": 0})
+    instance_to_test.update_known_position({"lat": 0, "lon": 0}, now_sec=current_time)
     instance_to_test.update_speed_mps(1.0)
     # move north 10 seconds
     current_time += 10.0
@@ -131,13 +132,13 @@ def test__when_one_known_and_sequence_of_moves__should_move_as_specified() -> No
 
 def test__when_moving_from_two_very_distant_knowns__distance_traveled_should_not_be_huge() -> None:
     instance_to_test = Localizer(start_time_sec=0)
-    instance_to_test.update_known_position({"lat": 0, "lon": 0})
+    instance_to_test.update_known_position({"lat": 0, "lon": 0}, now_sec=0.0)
     instance_to_test.update_speed_mps(1.0)
     instance_to_test.update_heading(0)
     instance_to_test.get_calculated_position(10)
 
     # known position is very far from previous
-    instance_to_test.update_known_position({"lat": 20, "lon": 20})
+    instance_to_test.update_known_position({"lat": 20, "lon": 20}, now_sec=10)
     instance_to_test.get_calculated_position(20)
 
     actual = round(instance_to_test.get_total_meters_traveled(), 1)
@@ -150,15 +151,15 @@ def positions_are_close(pos_1: LatLon, pos_2: LatLon) -> bool:
     )
 
 
-def test__when_depth_is_three_decimeters__should_discard_gps_position() -> None:
+def test__when_depth_at_blackout_enter__should_discard_gps_position() -> None:
     instance_to_test = Localizer(start_time_sec=0)
-    instance_to_test.update_known_position({"lat": 0, "lon": 0})
+    instance_to_test.update_known_position({"lat": 0, "lon": 0}, now_sec=0.0)
     instance_to_test.update_speed_mps(1.0)
     instance_to_test.update_heading(0)
 
     position_before_dive = instance_to_test.get_calculated_position(time.time())
 
-    instance_to_test.update_depth(0.3)
+    instance_to_test.update_depth(0.35)
     wonky_position_under_water: LatLon = {"lat": 1, "lon": 1}
     instance_to_test.update_known_position(wonky_position_under_water)
     position_after_dive = instance_to_test.get_calculated_position(time.time())
@@ -172,9 +173,99 @@ def test__when_depth_is_three_decimeters__should_discard_gps_position() -> None:
     )
 
 
+def test__when_surfacing_with_lone_bad_fix__should_not_snap() -> None:
+    localizer = Localizer(start_time_sec=0)
+    localizer.update_known_position({"lat": 0.0, "lon": 0.0}, now_sec=0.0)
+    localizer.update_depth(0.4, now_sec=0.0)
+    localizer.get_calculated_position(10.0)
+    position_before_surface = localizer.get_calculated_position(20.0)
+
+    localizer.update_depth(0.1, now_sec=20.0)
+    localizer.update_known_position({"lat": 1.0, "lon": 1.0}, now_sec=21.0)
+    position_after_bad_fix = localizer.get_calculated_position(22.0)
+
+    assert position_before_surface and position_after_bad_fix
+    assert positions_are_close(position_before_surface, position_after_bad_fix)
+
+
+def test__when_reacquiring_starts_at_zero__should_still_apply_timeout() -> None:
+    config = GnssBlackoutConfig(
+        enter_depth_m=0.35,
+        exit_depth_m=0.15,
+        cluster_radius_m=5.0,
+        fixes_required=2,
+        max_outlier_distance_m=1000.0,
+        reacquire_timeout_sec=10.0,
+    )
+    localizer = Localizer(start_time_sec=0, gnss_config=config)
+    localizer.update_known_position({"lat": 0.0, "lon": 0.0}, now_sec=0.0)
+    localizer.update_depth(0.4, now_sec=0.0)
+    localizer.update_depth(0.1, now_sec=0.0)
+    localizer.update_known_position({"lat": 0.0001, "lon": 0.0001}, now_sec=5.0)
+    position_before_timeout = localizer.get_calculated_position(5.0)
+
+    localizer.update_known_position({"lat": 0.0001, "lon": 0.0001}, now_sec=11.0)
+    position_after_timeout = localizer.get_calculated_position(11.0)
+
+    assert position_before_timeout and position_after_timeout
+    assert not positions_are_close(position_before_timeout, {"lat": 0.0001, "lon": 0.0001})
+    assert positions_are_close(position_after_timeout, {"lat": 0.0001, "lon": 0.0001})
+
+
+def test__when_surfacing_with_agreeing_fixes__should_snap_to_cluster() -> None:
+    localizer = Localizer(start_time_sec=0)
+    localizer.update_known_position({"lat": 0.0, "lon": 0.0}, now_sec=0.0)
+    localizer.update_depth(0.4, now_sec=0.0)
+    localizer.get_calculated_position(10.0)
+
+    localizer.update_depth(0.1, now_sec=20.0)
+    localizer.update_known_position({"lat": 0.0001, "lon": 0.0001}, now_sec=21.0)
+    localizer.update_known_position({"lat": 0.00011, "lon": 0.00011}, now_sec=22.0)
+    position = localizer.get_calculated_position(23.0)
+
+    assert position
+    assert positions_are_close({"lat": 0.000105, "lon": 0.000105}, position)
+    assert not positions_are_close({"lat": 0.0, "lon": 0.0}, position)
+
+
+def test__when_gnss_fix_arrives_between_ticks__should_not_overshoot_from_new_anchor() -> None:
+    localizer = Localizer(start_time_sec=0)
+    localizer.update_known_position({"lat": 0.0, "lon": 0.0}, now_sec=0.0)
+    localizer.update_speed_mps(1.0)
+    localizer.update_heading(0.0)
+    localizer.get_calculated_position(10.0)
+    localizer.update_known_position({"lat": 0.0001, "lon": 0.0}, now_sec=15.0)
+    position = localizer.get_calculated_position(20.0)
+
+    assert position
+    assert localizer.get_total_meters_traveled() == 15.0
+
+
+def test__when_position_tick_is_out_of_order__should_not_rewind_clock() -> None:
+    localizer = Localizer(start_time_sec=0)
+    localizer.update_known_position({"lat": 0.0, "lon": 0.0}, now_sec=0.0)
+    localizer.update_speed_mps(1.0)
+    localizer.get_calculated_position(10.0)
+    localizer.get_calculated_position(5.0)
+    localizer.get_calculated_position(20.0)
+
+    assert localizer.get_total_meters_traveled() == 20.0
+
+
+def test__when_gnss_fix_timestamp_is_older_than_last_tick__should_not_rewind_clock() -> None:
+    localizer = Localizer(start_time_sec=0)
+    localizer.update_known_position({"lat": 0.0, "lon": 0.0}, now_sec=0.0)
+    localizer.update_speed_mps(1.0)
+    localizer.get_calculated_position(10.0)
+    localizer.update_known_position({"lat": 0.0001, "lon": 0.0}, now_sec=5.0)
+    localizer.get_calculated_position(20.0)
+
+    assert localizer.get_total_meters_traveled() == 20.0
+
+
 def test__when_speed_zero_and_drift_one_mps_should_give_new_position() -> None:
     instance_to_test = Localizer(start_time_sec=0)
-    instance_to_test.update_known_position({"lat": 0, "lon": 0})
+    instance_to_test.update_known_position({"lat": 0, "lon": 0}, now_sec=0.0)
     instance_to_test.update_drift_speed_mps(1.0)
     instance_to_test.update_drift_bearing(90.0)  # Should be east bound
     position_after_one_sec = instance_to_test.get_calculated_position(1.0)
@@ -184,7 +275,7 @@ def test__when_speed_zero_and_drift_one_mps_should_give_new_position() -> None:
 
 def test__when_speed_zero_and_drift_one_mps_should_drift_one_meter_after_one_second() -> None:
     instance_to_test = Localizer(start_time_sec=0)
-    instance_to_test.update_known_position({"lat": 0, "lon": 0})
+    instance_to_test.update_known_position({"lat": 0, "lon": 0}, now_sec=0.0)
     instance_to_test.update_drift_speed_mps(1.0)
     instance_to_test.update_drift_bearing(90.0)  # Should be east bound
     position_after_one_sec = instance_to_test.get_calculated_position(1.0)
@@ -194,7 +285,7 @@ def test__when_speed_zero_and_drift_one_mps_should_drift_one_meter_after_one_sec
 
 def test__when_speed_zero_and_drift_zero_mps_should_not_drift() -> None:
     instance_to_test = Localizer(start_time_sec=0)
-    instance_to_test.update_known_position({"lat": 0, "lon": 0})
+    instance_to_test.update_known_position({"lat": 0, "lon": 0}, now_sec=0.0)
     position_after_one_sec = instance_to_test.get_calculated_position(1.0)
 
     assert position_after_one_sec and positions_are_close({"lat": 0.0, "lon": 0.0}, position_after_one_sec)

--- a/src/eel/test/eel/mqtt_bridge/inbound_validation_test.py
+++ b/src/eel/test/eel/mqtt_bridge/inbound_validation_test.py
@@ -1,0 +1,77 @@
+import json
+
+from eel.mqtt_bridge.inbound_validation import (
+    parse_bool_payload,
+    parse_coordinate_payload,
+    parse_depth_control_payload,
+    parse_float_payload,
+    parse_mission_payload,
+    parse_string_payload,
+)
+
+
+def test__when_string_payload_has_surrounding_whitespace__should_return_stripped() -> None:
+    assert parse_string_payload(json.dumps({"data": " rotholmen_runt_2025 "}).encode()) == "rotholmen_runt_2025"
+
+
+def test__when_string_payload_is_whitespace_only__should_reject() -> None:
+    assert parse_string_payload(json.dumps({"data": "   "}).encode()) is None
+
+
+def test__when_bool_payload_is_string__should_reject() -> None:
+    assert parse_bool_payload(json.dumps({"data": "false"}).encode()) is None
+
+
+def test__when_float_payload_is_bool__should_reject() -> None:
+    assert parse_float_payload(json.dumps({"data": True}).encode()) is None
+
+
+def test__when_coordinate_payload_uses_bools__should_reject() -> None:
+    assert parse_coordinate_payload(json.dumps({"lat": True, "lon": True}).encode()) is None
+
+
+def test__when_depth_control_targets_are_bool__should_reject() -> None:
+    payload = json.dumps(
+        {
+            "depth_target": True,
+            "pitch_target": False,
+            "depth_pid_type": "some_overshoot",
+            "pitch_pid_type": "some_overshoot",
+        }
+    ).encode()
+    assert parse_depth_control_payload(payload) is None
+
+
+def test__when_depth_control_missing_pid_type__should_reject() -> None:
+    payload = json.dumps({"depth_target": 1.0, "pitch_target": 0.0}).encode()
+    assert parse_depth_control_payload(payload) is None
+
+
+def test__when_mission_sync_after_is_string__should_reject() -> None:
+    payload = json.dumps(
+        {
+            "assignments": [
+                {
+                    "coordinate": {"lat": 59.0, "lon": 18.0},
+                    "target_depth": 1.0,
+                    "sync_after": "false",
+                }
+            ]
+        }
+    ).encode()
+    assert parse_mission_payload(payload) is None
+
+
+def test__when_mission_coordinate_uses_bools__should_reject() -> None:
+    payload = json.dumps(
+        {
+            "assignments": [
+                {
+                    "coordinate": {"lat": True, "lon": 18.0},
+                    "target_depth": 1.0,
+                    "sync_after": False,
+                }
+            ]
+        }
+    ).encode()
+    assert parse_mission_payload(payload) is None

--- a/src/eel/test/eel/pressure/pressure_serial_frames_test.py
+++ b/src/eel/test/eel/pressure/pressure_serial_frames_test.py
@@ -1,0 +1,30 @@
+import struct
+
+from eel.pressure.pressure_serial_frames import take_float32_le
+
+
+def test__when_fewer_than_four_bytes__should_keep_all_as_leftover() -> None:
+    values, leftover = take_float32_le(b"\x01\x02\x03")
+    assert values == []
+    assert leftover == b"\x01\x02\x03"
+
+
+def test__when_exactly_one_float__should_decode_and_leave_empty() -> None:
+    payload = struct.pack("<f", 1.5)
+    values, leftover = take_float32_le(payload)
+    assert values == [1.5]
+    assert leftover == b""
+
+
+def test__when_partial_trailing_bytes__should_keep_them_for_next_read() -> None:
+    payload = struct.pack("<f", 2.0) + b"\xaa\xbb"
+    values, leftover = take_float32_le(payload)
+    assert values == [2.0]
+    assert leftover == b"\xaa\xbb"
+
+
+def test__when_two_floats__should_decode_both() -> None:
+    payload = struct.pack("<f", 1.0) + struct.pack("<f", -3.25)
+    values, leftover = take_float32_le(payload)
+    assert values == [1.0, -3.25]
+    assert leftover == b""

--- a/src/eel/test/eel/tank/tank_target_test.py
+++ b/src/eel/test/eel/tank/tank_target_test.py
@@ -1,0 +1,61 @@
+import pytest
+from eel.tank.tank_target import (
+    RunningAverage,
+    TankTargetConfig,
+    is_at_ceiling,
+    is_at_floor,
+    is_within_accepted_target_boundaries,
+    tank_stop_reason,
+)
+
+# 0–100 scale with round margins so tests read without hidden constants.
+TEST_CONFIG = TankTargetConfig(
+    level_floor=0.0,
+    level_ceiling=100.0,
+    edge_margin=10.0,
+    target_half_band=5.0,
+)
+
+
+def test__when_level_at_target__should_be_within_boundaries() -> None:
+    assert is_within_accepted_target_boundaries(50.0, 50.0, TEST_CONFIG)
+
+
+def test__when_level_is_none__should_not_be_within_boundaries() -> None:
+    assert not is_within_accepted_target_boundaries(None, 50.0, TEST_CONFIG)
+
+
+def test__when_level_within_edge_margin_of_floor__should_be_at_floor() -> None:
+    assert is_at_floor(10.0, TEST_CONFIG)
+
+
+def test__when_level_within_edge_margin_of_ceiling__should_be_at_ceiling() -> None:
+    assert is_at_ceiling(90.0, TEST_CONFIG)
+
+
+def test__when_at_floor_and_target_not_above_level__should_stop_for_floor() -> None:
+    assert tank_stop_reason(level_average=0.0, target_level=0.0, config=TEST_CONFIG) == "floor_reached"
+
+
+def test__when_at_ceiling_and_target_not_below_level__should_stop_for_ceiling() -> None:
+    assert tank_stop_reason(level_average=100.0, target_level=100.0, config=TEST_CONFIG) == "ceiling_reached"
+
+
+def test__when_within_target_band__should_stop_for_target() -> None:
+    assert tank_stop_reason(level_average=50.0, target_level=50.0, config=TEST_CONFIG) == "target_reached"
+
+
+def test__when_still_adjusting__should_return_no_stop_reason() -> None:
+    assert tank_stop_reason(level_average=20.0, target_level=80.0, config=TEST_CONFIG) is None
+
+
+def test__when_running_average_filled__should_return_mean() -> None:
+    avg = RunningAverage(2)
+    avg.add_sample(0.0)
+    avg.add_sample(100.0)
+    assert avg.get_average() == 50.0
+
+
+def test__when_running_average_size_is_zero__should_raise() -> None:
+    with pytest.raises(ValueError):
+        RunningAverage(0)

--- a/src/eel/test/eel/utils/mission_bounds_test.py
+++ b/src/eel/test/eel/utils/mission_bounds_test.py
@@ -1,0 +1,36 @@
+from eel.utils.mission_bounds import are_mission_waypoints_valid, is_mission_waypoint_valid
+
+MAX_DEPTH_M = 3.0
+
+
+def test__when_mission_has_no_waypoints__should_accept() -> None:
+    assert are_mission_waypoints_valid([])
+
+
+def test__when_waypoint_is_within_limits__should_accept() -> None:
+    assert is_mission_waypoint_valid(59.0, 18.0, 1.0, max_depth_m=MAX_DEPTH_M)
+
+
+def test__when_coordinate_lat_is_invalid__should_reject() -> None:
+    assert not is_mission_waypoint_valid(91.0, 18.0, 1.0, max_depth_m=MAX_DEPTH_M)
+
+
+def test__when_coordinate_lon_is_invalid__should_reject() -> None:
+    assert not is_mission_waypoint_valid(59.0, 181.0, 1.0, max_depth_m=MAX_DEPTH_M)
+
+
+def test__when_target_depth_exceeds_max__should_reject() -> None:
+    assert not is_mission_waypoint_valid(59.0, 18.0, 4.0, max_depth_m=MAX_DEPTH_M)
+
+
+def test__when_target_depth_is_nan__should_reject() -> None:
+    assert not is_mission_waypoint_valid(59.0, 18.0, float("nan"), max_depth_m=MAX_DEPTH_M)
+
+
+def test__when_target_depth_is_infinite__should_reject() -> None:
+    assert not is_mission_waypoint_valid(59.0, 18.0, float("inf"), max_depth_m=MAX_DEPTH_M)
+
+
+def test__when_one_waypoint_is_invalid__should_reject_mission() -> None:
+    waypoints = [(59.0, 18.0, 1.0), (59.0, 18.0, float("inf"))]
+    assert not are_mission_waypoints_valid(waypoints, max_depth_m=MAX_DEPTH_M)

--- a/src/eel/test/eel/utils/pid_controller_test.py
+++ b/src/eel/test/eel/utils/pid_controller_test.py
@@ -1,0 +1,63 @@
+from eel.utils.pid_controller import OutputLimits, PidController, PidGains, PidState, pid_step
+
+
+def test__when_saturated_with_back_calculation__should_not_wind_integral() -> None:
+    state = PidState()
+    gains = PidGains(kP=0.0, kI=1.0, kD=0.0)
+    limits = OutputLimits(min=0.0, max=1.0)
+
+    for _ in range(20):
+        output, state = pid_step(state, measured=0.0, setpoint=10.0, gains=gains, dt=1.0, limits=limits)
+        assert output == 1.0
+
+    assert state.cumulative_error < 2.0
+
+
+def test__when_no_limits__should_return_unclamped_output() -> None:
+    state = PidState()
+    gains = PidGains(kP=2.0, kI=0.0, kD=0.0)
+
+    output, _ = pid_step(state, measured=1.0, setpoint=5.0, gains=gains, dt=0.1, limits=None)
+
+    assert output == 8.0
+
+
+def test__when_output_clamped__should_respect_limits() -> None:
+    state = PidState()
+    gains = PidGains(kP=10.0, kI=0.0, kD=0.0)
+    limits = OutputLimits(min=-1.0, max=1.0)
+
+    output, _ = pid_step(state, measured=0.0, setpoint=10.0, gains=gains, dt=0.1, limits=limits)
+
+    assert output == 1.0
+
+
+def test__when_ki_zero_and_clamped__should_clamp_without_using_integral() -> None:
+    state = PidState()
+    gains = PidGains(kP=50.0, kI=0.0, kD=0.0)
+    limits = OutputLimits(min=-1.0, max=1.0)
+
+    output, state = pid_step(state, measured=0.0, setpoint=10.0, gains=gains, dt=1.0, limits=limits)
+
+    assert output == 1.0
+    assert state.cumulative_error == 10.0
+
+
+def test__when_dt_zero_and_clamped__should_not_back_calculate_integral() -> None:
+    state = PidState()
+    gains = PidGains(kP=10.0, kI=1.0, kD=0.0)
+    limits = OutputLimits(min=-1.0, max=1.0)
+
+    output, state = pid_step(state, measured=0.0, setpoint=10.0, gains=gains, dt=0.0, limits=limits)
+
+    assert output == 1.0
+    assert state.cumulative_error == 0.0
+
+
+def test__when_output_limits_are_swapped__should_raise() -> None:
+    pid = PidController(set_point=0.0)
+    try:
+        pid.update_output_limits(1.0, -1.0)
+        raise AssertionError("expected ValueError")
+    except ValueError:
+        pass


### PR DESCRIPTION
## Summary
- **#151** — Buffer/resync pressure serial float frames so short reads cannot permanently misalign depth
- **#160** — PID anti-windup and output clamping so integral does not grow while rudder/tank outputs are saturated
- **#167** — Extract `tank_stop_reason` helpers with unit tests; remove dead tank velocity code
- **#181** — Configurable GNSS blackout gate with hysteresis and fix clustering on surfacing
- **#194** — Bound and validate MQTT-driven actuator commands at node boundaries (motor, rudder, tank, depth, nav, localization)
- **#149** — Replace runtime `print()` with ROS logging in navigation, motor sim, and serial helpers
- **#188** — Triage inline TODOs: remove stale ones, track the rest as #232–#243
- **#197** — Decouple `ImuSimulator` from `ImuNode` (circular import / typing)
- Document Bar02 → i2c-proxy → USB float stream in `docs/pressure-depth.md`

Fixes #149, #151, #160, #167, #181, #188, #194

## Test plan
- [x] `source source_me.sh && make test` (95 tests)
- [ ] Sim stack: pressure, tank stop at bounds, navigate mission load, MQTT cmd rejection for out-of-range values
- [ ] Pi: GNSS blackout/surface behavior, pressure reads after serial glitch