### PR TITLE
World-sim path 3: plant + pressure I/O split (WIP)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ typecheck-core:
 
 typecheck: check-sourced typecheck-core		## Run mypy on the eel package
 
-LINT_PATHS := src/eel/eel src/eel/test src/eel_bringup scripts tests
+LINT_PATHS := src/eel/eel src/eel/test src/eel_bringup src/eel_world_sim scripts tests
 
 lint:		## Run ruff lint + format check (no auto-fix)
 	ruff check $(LINT_PATHS)

--- a/docs/world-sim-first-iteration.md
+++ b/docs/world-sim-first-iteration.md
@@ -1,0 +1,41 @@
+# World sim — first iteration goals
+
+**Temporary** — delete this file before merging the finished work to `main`.
+
+Related: [#212](https://github.com/foxpoint-se/eel/issues/212)
+
+## Idea
+
+Same pattern as Stonefish/Gazebo: a **plant** owns the fake world (vehicle pose, crude dynamics). Sensor nodes stay ordinary and only read plant state. Later we can swap our plant for Stonefish behind the same kind of ROS edge.
+
+## First mergeable step
+
+Additive: run the world plant **as well**. Existing nodes keep their built-in sim; everything still works as today. No big-bang cutover.
+
+## Goals
+
+- **Launch** — New bringup launch for robot graph + plant. Grow it over time. Sibling launches later for real HW / our sim / other sims (same pattern). Not “one launch for everything” in this slice.
+- **Depth only** — Plant holds vehicle state and the dive model (e.g. thrust + pitch → depth). Publishes depth; pressure path does not invent physics or subscribe to motor/IMU.
+- **Pressure stub without physics** — `simulate:=true` (or equivalent) still runs off-Pi for CI / integration tests, with no cross-topic physics — dumb readings only. Plant is what makes depth move when you want a fake world.
+- **Clean graph** — Plant is the busy node. Pressure no longer looks like it secretly owns the boat.
+- **Move physics out of pressure** — Delete the cross-topic sim math from the pressure sim path (after the additive step above).
+- **Topic contract** — Write down: plant subscribes to X, publishes Y; who publishes `pressure/status`. Pick one story and stick to it.
+- **Minimal GUI** — Show depth + driving cmds; controls publish the **real** cmd topics (not a private channel). Enough to demo without only reading logs.
+- **One real consumer** — Something besides the GUI still sees depth (e.g. depth control / localization).
+- **Package** — Clear package boundary in this repo (e.g. plant + GUI). Stay in eel for now; own repo later if needed.
+- **Lightly reusable** — Think “water-world plant,” but don’t build a multi-robot framework in v1.
+
+## Non-goals
+
+Full mission stack, IMU/GNSS/tanks plant, Stonefish integration, fancy GUI, new repo.
+
+## Done when
+
+- [ ] Sim launch entry exists and is clearly the place to grow
+- [ ] World plant can run alongside existing stack without breaking normal sim
+- [ ] Depth comes from plant when using the world; pressure sim has no physics (stub only for CI)
+- [ ] Graph and publisher story match the written contract
+- [ ] Tiny GUI: state + cmds on real topics
+- [ ] At least one non-GUI consumer still works
+- [ ] In-repo package boundary; no new repo
+- [ ] This doc deleted before merge

--- a/docs/world-sim-first-iteration.md
+++ b/docs/world-sim-first-iteration.md
@@ -20,6 +20,7 @@ Additive: run the world plant **as well**. Existing nodes keep their built-in si
 - **Clean graph** — Plant is the busy node. Pressure no longer looks like it secretly owns the boat.
 - **Move physics out of pressure** — Delete the cross-topic sim math from the pressure sim path (after the additive step above).
 - **Topic contract** — Write down: plant subscribes to X, publishes Y; who publishes `pressure/status`. Pick one story and stick to it.
+- **Standard msgs at the plant edge** — Prefer common ROS types where we can (e.g. `sensor_msgs/FluidPressure`, later `Imu` / `Odometry`), with a thin translation to eel topics/msgs (`pressure/status`, …). Either start that way early, or ship a simpler plant first and refactor to this pattern once it works — decide when we hit the contract.
 - **Minimal GUI** — Show depth + driving cmds; controls publish the **real** cmd topics (not a private channel). Enough to demo without only reading logs.
 - **One real consumer** — Something besides the GUI still sees depth (e.g. depth control / localization).
 - **Package** — Clear package boundary in this repo (e.g. plant + GUI). Stay in eel for now; own repo later if needed.
@@ -27,7 +28,11 @@ Additive: run the world plant **as well**. Existing nodes keep their built-in si
 
 ## Non-goals
 
-Full mission stack, IMU/GNSS/tanks plant, Stonefish integration, fancy GUI, new repo.
+Full mission stack, IMU/GNSS/tanks plant, Stonefish integration, fancy GUI, new repo, URDF-driven physics.
+
+## Later / discuss
+
+- **URDF** — A simple robot model (e.g. cylinder + mass) that the plant actually *uses* for dynamics — not RViz-only eye candy — and that could feed Gazebo/Stonefish later. Stonefish won’t take URDF as drop-in; parsing URDF into our crude plant is a real chunk of work. Park for now; likely spin out a separate issue when we revisit.
 
 ## Done when
 

--- a/docs/world-sim-first-iteration.md
+++ b/docs/world-sim-first-iteration.md
@@ -12,7 +12,7 @@ Same pattern as Stonefish/Gazebo: a **plant** owns the fake world (vehicle pose,
 
 **Goal:** new lightweight package + a plant that owns the depth physics we lift from pressure. Easy to run. Existing stack keeps working as today (old built-in sims still there); you run the world plant *as well*.
 
-- [ ] New in-repo package (clear home for plant; name TBD)
+- [x] New in-repo package `eel_world_sim` (clear home for plant)
 - [ ] Plant node runs today’s depth math (logic taken from pressure sim)
 - [ ] Plant publishes depth on a clear topic (contract can be rough)
 - [ ] Simple launch: start plant alone, and/or alongside existing sim stack

--- a/docs/world-sim-first-iteration.md
+++ b/docs/world-sim-first-iteration.md
@@ -8,11 +8,20 @@ Related: [#212](https://github.com/foxpoint-se/eel/issues/212)
 
 Same pattern as Stonefish/Gazebo: a **plant** owns the fake world (vehicle pose, crude dynamics). Sensor nodes stay ordinary and only read plant state. Later we can swap our plant for Stonefish behind the same kind of ROS edge.
 
-## First mergeable step
+## Phase 1 — Plant home (additive)
 
-Additive: run the world plant **as well**. Existing nodes keep their built-in sim; everything still works as today. No big-bang cutover.
+**Goal:** new lightweight package + a plant that owns the depth physics we lift from pressure. Easy to run. Existing stack keeps working as today (old built-in sims still there); you run the world plant *as well*.
 
-## Goals
+- [ ] New in-repo package (clear home for plant; name TBD)
+- [ ] Plant node runs today’s depth math (logic taken from pressure sim)
+- [ ] Plant publishes depth on a clear topic (contract can be rough)
+- [ ] Simple launch: start plant alone, and/or alongside existing sim stack
+- [ ] Nothing broken — pressure / CI / normal sim still behave as now
+- [ ] Sanity check: `ros2 topic echo` (or graph) shows plant depth moving when cmds change
+
+Out of Phase 1: gutting pressure physics, stub-only pressure, GUI, standard-msg edge, URDF.
+
+## Goals (full first iteration)
 
 - **Launch** — New bringup launch for robot graph + plant. Grow it over time. Sibling launches later for real HW / our sim / other sims (same pattern). Not “one launch for everything” in this slice.
 - **Depth only** — Plant holds vehicle state and the dive model (e.g. thrust + pitch → depth). Publishes depth; pressure path does not invent physics or subscribe to motor/IMU.

--- a/docs/world-sim-first-iteration.md
+++ b/docs/world-sim-first-iteration.md
@@ -4,52 +4,58 @@
 
 Related: [#212](https://github.com/foxpoint-se/eel/issues/212)
 
-## Idea
+## Target architecture (path 3)
 
-Same pattern as Stonefish/Gazebo: a **plant** owns the fake world (vehicle pose, crude dynamics). Sensor nodes stay ordinary and only read plant state. Later we can swap our plant for Stonefish behind the same kind of ROS edge.
+Same idea as TurtleBot / Clearpath / Stonefish / Gazebo bringups:
 
-## Phase 1 — Plant home (additive)
+1. **Plant** — owns fake-world physics (depth first).
+2. **Device I/O** — chip drivers only (Bar02, BNO055, …). Started on the **boat**, not in full world-sim.
+3. **Robot logic** — always runs (center depth, velocity, `PressureStatus`, nav, …).
 
-**Goal:** new lightweight package + a plant that owns the depth physics we lift from pressure. Easy to run. Existing stack keeps working as today (old built-in sims still there); you run the world plant *as well*.
+In sim: **don’t start chip I/O**. Plant (or later Gazebo/Stonefish) supplies **raw/sensor-level** data. Logic keeps publishing eel topics (`pressure/status`, …).
 
-- [x] New in-repo package `eel_world_sim` (clear home for plant)
-- [ ] Plant node runs today’s depth math (logic taken from pressure sim)
-- [ ] Plant publishes depth on a clear topic (contract can be rough)
-- [ ] Simple launch: start plant alone, and/or alongside existing sim stack
-- [ ] Nothing broken — pressure / CI / normal sim still behave as now
-- [ ] Sanity check: `ros2 topic echo` (or graph) shows plant depth moving when cmds change
+**Not the goal:** every device node subscribes to plant topics and stuffs values in (path 1 — today’s `pressure_sim` mess).  
+**Not the long-term story alone:** in-memory DI drivers in one process (path 2) — fine as an *implementation detail* for our small plant, but Gazebo/Stonefish are other processes that speak ROS topics / plugins.
 
-Out of Phase 1: gutting pressure physics, stub-only pressure, GUI, standard-msg edge, URDF.
+**Plant edge:** prefer standard ROS msgs where practical (`sensor_msgs/FluidPressure`, later `Imu`, …), with a thin adapt into eel msgs. That prepares switching to Stonefish/Gazebo.
 
-## Goals (full first iteration)
+## Phase 1 — Plant + start pressure split (path 3)
 
-- **Launch** — New bringup launch for robot graph + plant. Grow it over time. Sibling launches later for real HW / our sim / other sims (same pattern). Not “one launch for everything” in this slice.
-- **Depth only** — Plant holds vehicle state and the dive model (e.g. thrust + pitch → depth). Publishes depth; pressure path does not invent physics or subscribe to motor/IMU.
-- **Pressure stub without physics** — `simulate:=true` (or equivalent) still runs off-Pi for CI / integration tests, with no cross-topic physics — dumb readings only. Plant is what makes depth move when you want a fake world.
-- **Clean graph** — Plant is the busy node. Pressure no longer looks like it secretly owns the boat.
-- **Move physics out of pressure** — Delete the cross-topic sim math from the pressure sim path (after the additive step above).
-- **Topic contract** — Write down: plant subscribes to X, publishes Y; who publishes `pressure/status`. Pick one story and stick to it.
-- **Standard msgs at the plant edge** — Prefer common ROS types where we can (e.g. `sensor_msgs/FluidPressure`, later `Imu` / `Odometry`), with a thin translation to eel topics/msgs (`pressure/status`, …). Either start that way early, or ship a simpler plant first and refactor to this pattern once it works — decide when we hit the contract.
-- **Minimal GUI** — Show depth + driving cmds; controls publish the **real** cmd topics (not a private channel). Enough to demo without only reading logs.
-- **One real consumer** — Something besides the GUI still sees depth (e.g. depth control / localization).
-- **Package** — Clear package boundary in this repo (e.g. plant + GUI). Stay in eel for now; own repo later if needed.
-- **Lightly reusable** — Think “water-world plant,” but don’t build a multi-robot framework in v1.
+**Goal:** Plant owns depth physics. Begin separating pressure **chip I/O** from **logic** so we don’t build the wrong habit. Boat/CI still work.
 
-## Non-goals
+- [x] New in-repo package `eel_world_sim`
+- [ ] Plant runs today’s depth math (lifted from pressure sim); math separate from ROS I/O
+- [ ] Plant publishes **raw** depth (aim toward standard msg; not `pressure/status`)
+- [ ] Start pressure SoC split: clear boundary between “get raw depth” (I/O / source) and “build `PressureStatus`” (logic). Hardware and stub sources; **no** dive physics in pressure.
+- [ ] Stub/CI: pressure logic still runs with dumb raw depth (no plant, no hardware)
+- [ ] Simple launch: plant alone; optional plant + pressure-logic path for sanity
+- [ ] Sanity: plant depth moves with cmds; pressure logic can consume raw depth without `pressure_sim` physics
 
-Full mission stack, IMU/GNSS/tanks plant, Stonefish integration, fancy GUI, new repo, URDF-driven physics.
+Out of Phase 1: full IMU/etc. splits, GUI, Stonefish/Gazebo, URDF, polished multi-sim bringups.
+
+## Later phases (same iteration / follow-ups)
+
+- **Finish path-3 bringup** — sim launch: plant + logic, no chip drivers. Sibling launches: real / our world / (later) Stonefish|Gazebo.
+- **Delete dead pressure sim physics** — if anything remains after the split.
+- **Minimal GUI** — depth + cmds on real cmd topics.
+- **Contract written** — plant in/out; who publishes what.
+
+## Non-goals (now)
+
+Full mission stack, full IMU/GNSS/tanks plant, Stonefish/Gazebo integration, fancy GUI, new repo, URDF-driven physics, ros2_control.
 
 ## Later / discuss
 
-- **URDF** — A simple robot model (e.g. cylinder + mass) that the plant actually *uses* for dynamics — not RViz-only eye candy — and that could feed Gazebo/Stonefish later. Stonefish won’t take URDF as drop-in; parsing URDF into our crude plant is a real chunk of work. Park for now; likely spin out a separate issue when we revisit.
+- **URDF** — model the plant could *use* for dynamics (not RViz-only). Stonefish won’t take URDF as drop-in. Spin out an issue when relevant.
+- **ros2_control** — for motors/actuators later? Helps a lot with **Gazebo**; Stonefish is topic-based natively, so less automatic win. Revisit: when/whether it helps eel (few actuators, Python-first, Stonefish-oriented) vs cost.
 
-## Done when
+## Done when (first iteration)
 
-- [ ] Sim launch entry exists and is clearly the place to grow
-- [ ] World plant can run alongside existing stack without breaking normal sim
-- [ ] Depth comes from plant when using the world; pressure sim has no physics (stub only for CI)
-- [ ] Graph and publisher story match the written contract
-- [ ] Tiny GUI: state + cmds on real topics
-- [ ] At least one non-GUI consumer still works
-- [ ] In-repo package boundary; no new repo
+- [ ] Plant owns depth physics; pressure has no cross-topic dive math
+- [ ] Path 3 shape clear: chip I/O vs logic vs plant (even if only pressure is split)
+- [ ] Sim can run plant + logic without relying on `pressure_sim` physics
+- [ ] Stub/CI path still works without hardware or plant physics
+- [ ] Written topic/msg contract at the plant edge
+- [ ] Tiny GUI optional but useful
 - [ ] This doc deleted before merge
+- [ ] Interactive rebase (or similar) so the branch commits read cleanly for the changelog before merge

--- a/docs/world-sim-first-iteration.md
+++ b/docs/world-sim-first-iteration.md
@@ -59,3 +59,4 @@ Full mission stack, full IMU/GNSS/tanks plant, Stonefish/Gazebo integration, fan
 - [ ] Tiny GUI optional but useful
 - [ ] This doc deleted before merge
 - [ ] Interactive rebase (or similar) so the branch commits read cleanly for the changelog before merge
+- [ ] Clean up redundant files left by the parallel path (e.g. old `pressure_sensor.py` / `pressure_sim` physics once the new I/O + logic + plant path is confirmed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ tag_format = "v{version}"
 commit_parser = "conventional"
 build_command = """
 python3 scripts/sync_version.py
-git add src/eel/setup.py src/eel/package.xml src/eel_interfaces/package.xml src/eel_bringup/package.xml
+git add src/eel/setup.py src/eel/package.xml src/eel_interfaces/package.xml src/eel_bringup/package.xml src/eel_world_sim/setup.py src/eel_world_sim/package.xml
 """
 
 [tool.semantic_release.branches.main]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ match = "^main$"
 mode = "update"
 
 [tool.pytest.ini_options]
+pythonpath = ["src/eel_world_sim"]
 markers = [
     "launch_test: ROS launch test (requires sourced ROS + built workspace)",
 ]

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -14,6 +14,8 @@ TARGETS = (
     REPO_ROOT / "src" / "eel" / "package.xml",
     REPO_ROOT / "src" / "eel_interfaces" / "package.xml",
     REPO_ROOT / "src" / "eel_bringup" / "package.xml",
+    REPO_ROOT / "src" / "eel_world_sim" / "setup.py",
+    REPO_ROOT / "src" / "eel_world_sim" / "package.xml",
 )
 
 _SECTION_HEADER = re.compile(r"^\[([^\]]+)\]")

--- a/src/eel/eel/pressure/pressure_hardware_node.py
+++ b/src/eel/eel/pressure/pressure_hardware_node.py
@@ -8,9 +8,9 @@ from rclpy.parameter import Parameter
 from std_msgs.msg import Float32
 
 from ..utils.node_runner import spin_node_until_shutdown
+from ..utils.topics import PRESSURE_DEPTH_M
 from .pressure_serial_driver import PressureSerialDriver
 
-DEPTH_M_TOPIC = "pressure/depth_m"
 PUBLISH_HZ = 5.0
 
 
@@ -24,7 +24,7 @@ class PressureHardwareNode(Node):
 
         self._driver = PressureSerialDriver(serial_port)
         self._logged_calibration = False
-        self._pub = self.create_publisher(Float32, DEPTH_M_TOPIC, 10)
+        self._pub = self.create_publisher(Float32, PRESSURE_DEPTH_M, 10)
         self.create_timer(1.0 / PUBLISH_HZ, self._publish_depth)
         self.get_logger().info(f"Waiting for first depth sample on {serial_port}")
 

--- a/src/eel/eel/pressure/pressure_hardware_node.py
+++ b/src/eel/eel/pressure/pressure_hardware_node.py
@@ -20,7 +20,7 @@ class PressureHardwareNode(Node):
         self.declare_parameter("serial_port", Parameter.Type.STRING)
         serial_port = self.get_parameter("serial_port").get_parameter_value().string_value or None
         if not serial_port:
-            raise ValueError("serial_port is required, e.g. -p serial_port:=/dev/ttyUSB0")
+            raise ValueError("serial_port is required, e.g. --ros-args -p serial_port:=/dev/ttyUSB0")
 
         self._driver = PressureSerialDriver(serial_port)
         self._logged_calibration = False

--- a/src/eel/eel/pressure/pressure_hardware_node.py
+++ b/src/eel/eel/pressure/pressure_hardware_node.py
@@ -1,0 +1,54 @@
+"""Reads the pressure sensor over serial and publishes depth in meters."""
+
+from typing import Optional
+
+import rclpy
+from rclpy.node import Node
+from rclpy.parameter import Parameter
+from std_msgs.msg import Float32
+
+from ..utils.node_runner import spin_node_until_shutdown
+from .pressure_serial_driver import PressureSerialDriver
+
+DEPTH_M_TOPIC = "pressure/depth_m"
+PUBLISH_HZ = 5.0
+
+
+class PressureHardwareNode(Node):
+    def __init__(self) -> None:
+        super().__init__("pressure_hardware")
+        self.declare_parameter("serial_port", Parameter.Type.STRING)
+        serial_port = self.get_parameter("serial_port").get_parameter_value().string_value or None
+        if not serial_port:
+            raise ValueError("serial_port is required, e.g. -p serial_port:=/dev/ttyUSB0")
+
+        self._driver = PressureSerialDriver(serial_port)
+        self._logged_calibration = False
+        self._pub = self.create_publisher(Float32, DEPTH_M_TOPIC, 10)
+        self.create_timer(1.0 / PUBLISH_HZ, self._publish_depth)
+        self.get_logger().info(f"Waiting for first depth sample on {serial_port}")
+
+    def _publish_depth(self) -> None:
+        depth_m = self._driver.get_depth_m()
+        if depth_m is None:
+            return
+        if self._driver.is_calibrated and not self._logged_calibration:
+            self.get_logger().info("Atmosphere offset set from first sample")
+            self._logged_calibration = True
+
+        msg = Float32()
+        msg.data = depth_m
+        self._pub.publish(msg)
+
+    def close_driver(self) -> None:
+        self._driver.close()
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    rclpy.init(args=args)
+    node = PressureHardwareNode()
+    spin_node_until_shutdown(node, cleanup=node.close_driver)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eel/eel/pressure/pressure_math.py
+++ b/src/eel/eel/pressure/pressure_math.py
@@ -1,0 +1,21 @@
+"""Pure depth helpers for pressure app logic (no ROS)."""
+
+import math
+
+
+def calculate_center_depth(main_depth: float, pitch_deg: float, displacement: float = 0.375) -> float:
+    pitch_rad = math.radians(pitch_deg)
+    return main_depth - (displacement * math.sin(pitch_rad))
+
+
+def get_depth_velocity(
+    depth: float,
+    previous_depth: float | None,
+    now: float,
+    previous_depth_at: float | None,
+) -> float:
+    if previous_depth is None or previous_depth_at is None:
+        return 0.0
+    depth_delta = depth - previous_depth
+    time_delta = now - previous_depth_at
+    return depth_delta / time_delta

--- a/src/eel/eel/pressure/pressure_math.py
+++ b/src/eel/eel/pressure/pressure_math.py
@@ -16,6 +16,7 @@ def get_depth_velocity(
 ) -> float:
     if previous_depth is None or previous_depth_at is None:
         return 0.0
-    depth_delta = depth - previous_depth
     time_delta = now - previous_depth_at
-    return depth_delta / time_delta
+    if time_delta <= 0.0:
+        return 0.0
+    return (depth - previous_depth) / time_delta

--- a/src/eel/eel/pressure/pressure_new_node.py
+++ b/src/eel/eel/pressure/pressure_new_node.py
@@ -1,0 +1,73 @@
+"""Parallel pressure logic: raw depth_m + IMU → PressureStatus.
+
+Temporary name until this path replaces the old pressure node in bringup.
+"""
+
+from time import time
+from typing import Optional
+
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import Float32
+
+from eel_interfaces.msg import ImuStatus, PressureStatus
+
+from ..utils.node_runner import spin_node_until_shutdown
+from ..utils.topics import IMU_STATUS, PRESSURE_DEPTH_M, PRESSURE_STATUS
+from .pressure_math import calculate_center_depth, get_depth_velocity
+
+PUBLISH_HZ = 5.0
+
+
+class PressureNewNode(Node):
+    def __init__(self) -> None:
+        super().__init__("pressure_new")
+
+        self._sensor_depth_m: float | None = None
+        self._pitch_deg = 0.0
+        self._last_center_depth_m: float | None = None
+        self._last_center_at: float | None = None
+
+        self.create_subscription(Float32, PRESSURE_DEPTH_M, self._handle_depth_m, 10)
+        self.create_subscription(ImuStatus, IMU_STATUS, self._handle_imu, 10)
+        self._pub = self.create_publisher(PressureStatus, PRESSURE_STATUS, 10)
+        self.create_timer(1.0 / PUBLISH_HZ, self._publish_status)
+
+        self.get_logger().info(f"Pressure new started (listening on {PRESSURE_DEPTH_M})")
+
+    def _handle_depth_m(self, msg: Float32) -> None:
+        self._sensor_depth_m = float(msg.data)
+
+    def _handle_imu(self, msg: ImuStatus) -> None:
+        self._pitch_deg = float(msg.pitch)
+
+    def _publish_status(self) -> None:
+        if self._sensor_depth_m is None:
+            return
+
+        center_depth_m = calculate_center_depth(self._sensor_depth_m, self._pitch_deg)
+        now = time()
+        depth_velocity = get_depth_velocity(
+            center_depth_m,
+            self._last_center_depth_m,
+            now,
+            self._last_center_at,
+        )
+
+        out = PressureStatus()
+        out.depth = center_depth_m
+        out.depth_velocity = depth_velocity
+        self._pub.publish(out)
+
+        self._last_center_depth_m = center_depth_m
+        self._last_center_at = now
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    rclpy.init(args=args)
+    node = PressureNewNode()
+    spin_node_until_shutdown(node)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eel/eel/pressure/pressure_node.py
+++ b/src/eel/eel/pressure/pressure_node.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import math
 from time import time
 from typing import Optional
 
@@ -12,29 +11,11 @@ from eel_interfaces.msg import ImuStatus, PressureStatus
 from ..utils.constants import SIMULATE_PARAM
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import IMU_STATUS, PRESSURE_STATUS
+from .pressure_math import calculate_center_depth, get_depth_velocity
 from .pressure_source import PressureSource
 
 PUBLISH_FREQUENCY = 5
 DEPTH_MOVEMENT_TOLERANCE = 0.2  # meters
-
-
-def calculate_center_depth(main_depth: float, pitch_deg: float, displacement: float = 0.375) -> float:
-    pitch_rad = math.radians(pitch_deg)
-    return main_depth - (displacement * math.sin(pitch_rad))
-
-
-def get_depth_velocity(
-    depth: float,
-    previous_depth: float | None,
-    now: float,
-    previous_depth_at: float | None,
-) -> float:
-    if previous_depth is None or previous_depth_at is None:
-        return 0.0
-    depth_delta = depth - previous_depth
-    time_delta = now - previous_depth_at
-    velocity = depth_delta / time_delta
-    return velocity
 
 
 def get_pressure_sensor(should_simulate: bool, parent_node: Node, serial_port: str | None = None) -> PressureSource:

--- a/src/eel/eel/pressure/pressure_serial_driver.py
+++ b/src/eel/eel/pressure/pressure_serial_driver.py
@@ -1,0 +1,42 @@
+"""Serial driver for the Bar02 depth stream (meters). No ROS."""
+
+import serial
+
+from .pressure_serial_frames import FLOAT32_SIZE, take_float32_le
+
+
+class PressureSerialDriver:
+    def __init__(self, serial_port: str) -> None:
+        self._serial = serial.Serial(serial_port, timeout=0)
+        self._rx_buffer = b""
+        self._atmosphere_offset_m: float | None = None
+
+        self._serial.reset_input_buffer()
+        self._serial.reset_output_buffer()
+
+    @property
+    def is_calibrated(self) -> bool:
+        return self._atmosphere_offset_m is not None
+
+    def get_depth_m(self) -> float | None:
+        """Depth in meters relative to the first good sample (surface offset)."""
+        sample_m = self._read_depth_sample()
+        if sample_m is None:
+            return None
+        if self._atmosphere_offset_m is None:
+            self._atmosphere_offset_m = sample_m
+            return 0.0
+        return sample_m - self._atmosphere_offset_m
+
+    def close(self) -> None:
+        if self._serial.is_open:
+            self._serial.close()
+
+    def _read_depth_sample(self) -> float | None:
+        waiting = self._serial.in_waiting
+        to_read = waiting if waiting > 0 else FLOAT32_SIZE
+        self._rx_buffer += self._serial.read(to_read)
+        values, self._rx_buffer = take_float32_le(self._rx_buffer)
+        if not values:
+            return None
+        return values[-1]

--- a/src/eel/eel/utils/topics.py
+++ b/src/eel/eel/utils/topics.py
@@ -35,6 +35,7 @@ REAR_TANK_CMD = "tank_rear/cmd"
 REAR_TANK_STATUS = "tank_rear/status"
 
 # Pressure
+PRESSURE_DEPTH_M = "pressure/depth_m"
 PRESSURE_STATUS = "pressure/status"
 
 # Depth control

--- a/src/eel/setup.py
+++ b/src/eel/setup.py
@@ -50,6 +50,7 @@ setup(
             "motor = eel.motor.motor_node:main",
             "tank = eel.tank.tank_node:main",
             "pressure = eel.pressure.pressure_node:main",
+            "pressure_hardware = eel.pressure.pressure_hardware_node:main",
             "depth_control = eel.depth_control.depth_control_node:main",
             "depth_control_rudder = eel.depth_control.depth_control_node_rudder:main",
             "battery = eel.battery.battery_node:main",

--- a/src/eel/setup.py
+++ b/src/eel/setup.py
@@ -50,6 +50,7 @@ setup(
             "motor = eel.motor.motor_node:main",
             "tank = eel.tank.tank_node:main",
             "pressure = eel.pressure.pressure_node:main",
+            "pressure_new = eel.pressure.pressure_new_node:main",
             "pressure_hardware = eel.pressure.pressure_hardware_node:main",
             "depth_control = eel.depth_control.depth_control_node:main",
             "depth_control_rudder = eel.depth_control.depth_control_node_rudder:main",

--- a/src/eel/test/eel/pressure/pressure_math_test.py
+++ b/src/eel/test/eel/pressure/pressure_math_test.py
@@ -9,7 +9,7 @@ def test__when_pitch_is_zero__should_return_sensor_depth() -> None:
 
 def test__when_pitch_ninety__should_apply_lever_arm() -> None:
     expected = 2.0 - (0.375 * math.sin(math.radians(90.0)))
-    assert calculate_center_depth(2.0, 90.0, 0.375) == expected
+    assert math.isclose(calculate_center_depth(2.0, 90.0, 0.375), expected)
 
 
 def test__when_no_previous_sample__should_report_zero_velocity() -> None:

--- a/src/eel/test/eel/pressure/pressure_math_test.py
+++ b/src/eel/test/eel/pressure/pressure_math_test.py
@@ -18,3 +18,11 @@ def test__when_no_previous_sample__should_report_zero_velocity() -> None:
 
 def test__when_depth_increases_over_time__should_report_positive_velocity() -> None:
     assert get_depth_velocity(2.0, previous_depth=1.0, now=2.0, previous_depth_at=1.0) == 1.0
+
+
+def test__when_time_delta_is_zero__should_report_zero_velocity() -> None:
+    assert get_depth_velocity(2.0, previous_depth=1.0, now=1.0, previous_depth_at=1.0) == 0.0
+
+
+def test__when_clock_goes_backwards__should_report_zero_velocity() -> None:
+    assert get_depth_velocity(2.0, previous_depth=1.0, now=0.5, previous_depth_at=1.0) == 0.0

--- a/src/eel/test/eel/pressure/pressure_math_test.py
+++ b/src/eel/test/eel/pressure/pressure_math_test.py
@@ -1,0 +1,20 @@
+import math
+
+from eel.pressure.pressure_math import calculate_center_depth, get_depth_velocity
+
+
+def test__when_pitch_is_zero__should_return_sensor_depth() -> None:
+    assert calculate_center_depth(2.0, 0.0) == 2.0
+
+
+def test__when_pitch_ninety__should_apply_lever_arm() -> None:
+    expected = 2.0 - (0.375 * math.sin(math.radians(90.0)))
+    assert calculate_center_depth(2.0, 90.0, 0.375) == expected
+
+
+def test__when_no_previous_sample__should_report_zero_velocity() -> None:
+    assert get_depth_velocity(1.0, None, now=10.0, previous_depth_at=None) == 0.0
+
+
+def test__when_depth_increases_over_time__should_report_positive_velocity() -> None:
+    assert get_depth_velocity(2.0, previous_depth=1.0, now=2.0, previous_depth_at=1.0) == 1.0

--- a/src/eel_world_sim/eel_world_sim/depth_model.py
+++ b/src/eel_world_sim/eel_world_sim/depth_model.py
@@ -1,0 +1,46 @@
+"""Depth physics for the world plant. No ROS — numbers in, depth out.
+
+Lifted from eel.pressure.pressure_sim (same crude dive model).
+"""
+
+from math import radians, tan
+
+TERMINAL_VELOCITY_MPS = 0.3
+FLOAT_VELOCITY_MPS = -0.05  # slight positive buoyancy
+MAX_DEPTH_M = 10.0
+MIN_DEPTH_M = 0.0
+
+
+def _pitch_speed_velocity_mps(terminal_velocity_mps: float, pitch_deg: float) -> float:
+    return tan(radians(pitch_deg)) * terminal_velocity_mps
+
+
+def _cap_depth_m(depth_m: float) -> float:
+    return min(max(depth_m, MIN_DEPTH_M), MAX_DEPTH_M)
+
+
+class DepthModel:
+    """Integrates depth from pitch (deg) and motor cmd over time."""
+
+    def __init__(self) -> None:
+        self.depth_m = 0.0
+        self.pitch_deg = 0.0
+        self.motor_cmd = 0.0
+
+    def set_pitch_deg(self, pitch_deg: float) -> None:
+        self.pitch_deg = pitch_deg
+
+    def set_motor_cmd(self, motor_cmd: float) -> None:
+        self.motor_cmd = motor_cmd
+
+    def step(self, dt_s: float) -> float:
+        if dt_s <= 0.0:
+            return self.depth_m
+
+        dive_velocity_mps = (
+            _pitch_speed_velocity_mps(TERMINAL_VELOCITY_MPS, self.pitch_deg) * self.motor_cmd
+        )
+        velocity_mps = FLOAT_VELOCITY_MPS + dive_velocity_mps
+        if velocity_mps != 0.0:
+            self.depth_m = _cap_depth_m(self.depth_m + velocity_mps * dt_s)
+        return self.depth_m

--- a/src/eel_world_sim/eel_world_sim/depth_model.py
+++ b/src/eel_world_sim/eel_world_sim/depth_model.py
@@ -37,9 +37,7 @@ class DepthModel:
         if dt_s <= 0.0:
             return self.depth_m
 
-        dive_velocity_mps = (
-            _pitch_speed_velocity_mps(TERMINAL_VELOCITY_MPS, self.pitch_deg) * self.motor_cmd
-        )
+        dive_velocity_mps = _pitch_speed_velocity_mps(TERMINAL_VELOCITY_MPS, self.pitch_deg) * self.motor_cmd
         velocity_mps = FLOAT_VELOCITY_MPS + dive_velocity_mps
         if velocity_mps != 0.0:
             self.depth_m = _cap_depth_m(self.depth_m + velocity_mps * dt_s)

--- a/src/eel_world_sim/eel_world_sim/world_sim_node.py
+++ b/src/eel_world_sim/eel_world_sim/world_sim_node.py
@@ -8,10 +8,10 @@ from time import time
 from typing import Optional
 
 import rclpy
-from eel_interfaces.msg import ImuStatus
 from rclpy.node import Node
 from std_msgs.msg import Float32
 
+from eel_interfaces.msg import ImuStatus
 from eel_world_sim.depth_model import DepthModel
 
 # Temporary: same names as the live boat topics.

--- a/src/eel_world_sim/eel_world_sim/world_sim_node.py
+++ b/src/eel_world_sim/eel_world_sim/world_sim_node.py
@@ -1,0 +1,66 @@
+"""World plant ROS node.
+
+Topic names are hardcoded to match today's eel stack (temporary).
+When the plant edge is clearer, replace with remaps/params.
+"""
+
+from time import time
+from typing import Optional
+
+import rclpy
+from eel_interfaces.msg import ImuStatus
+from rclpy.node import Node
+from std_msgs.msg import Float32
+
+from eel_world_sim.depth_model import DepthModel
+
+# Temporary: same names as the live boat topics.
+MOTOR_CMD_TOPIC = "motor/cmd"
+IMU_STATUS_TOPIC = "imu/status"
+WORLD_DEPTH_TOPIC = "world/depth"
+
+PUBLISH_HZ = 10.0
+
+
+class WorldSimNode(Node):
+    def __init__(self) -> None:
+        super().__init__("world_sim")
+        self._depth_model = DepthModel()
+        self._last_step_at = time()
+
+        self.create_subscription(Float32, MOTOR_CMD_TOPIC, self._on_motor_cmd, 10)
+        self.create_subscription(ImuStatus, IMU_STATUS_TOPIC, self._on_imu_status, 10)
+        self._depth_pub = self.create_publisher(Float32, WORLD_DEPTH_TOPIC, 10)
+        self.create_timer(1.0 / PUBLISH_HZ, self._on_timer)
+
+    def _on_motor_cmd(self, msg: Float32) -> None:
+        self._depth_model.set_motor_cmd(float(msg.data))
+
+    def _on_imu_status(self, msg: ImuStatus) -> None:
+        self._depth_model.set_pitch_deg(float(msg.pitch))
+
+    def _on_timer(self) -> None:
+        now = time()
+        dt_s = now - self._last_step_at
+        self._last_step_at = now
+
+        depth_m = self._depth_model.step(dt_s)
+        out = Float32()
+        out.data = depth_m
+        self._depth_pub.publish(out)
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    rclpy.init(args=args)
+    node = WorldSimNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eel_world_sim/package.xml
+++ b/src/eel_world_sim/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>eel_world_sim</name>
+  <version>1.2.12</version>
+  <description>Simple fake-world simulation for local eel development.</description>
+  <maintainer email="foxpoint.se@gmail.com">Foxpoint marinrobotik</maintainer>
+  <license>MIT</license>
+
+  <depend>rclpy</depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/src/eel_world_sim/package.xml
+++ b/src/eel_world_sim/package.xml
@@ -8,6 +8,8 @@
   <license>MIT</license>
 
   <depend>rclpy</depend>
+  <depend>std_msgs</depend>
+  <depend>eel_interfaces</depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/src/eel_world_sim/setup.cfg
+++ b/src/eel_world_sim/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/eel_world_sim
+[install]
+install_scripts=$base/lib/eel_world_sim

--- a/src/eel_world_sim/setup.py
+++ b/src/eel_world_sim/setup.py
@@ -16,4 +16,9 @@ setup(
     maintainer_email="foxpoint.se@gmail.com",
     description="Simple fake-world simulation for local eel development.",
     license="MIT",
+    entry_points={
+        "console_scripts": [
+            "world_sim = eel_world_sim.world_sim_node:main",
+        ],
+    },
 )

--- a/src/eel_world_sim/setup.py
+++ b/src/eel_world_sim/setup.py
@@ -1,0 +1,19 @@
+from setuptools import find_packages, setup
+
+package_name = "eel_world_sim"
+
+setup(
+    name=package_name,
+    version="1.2.12",
+    packages=find_packages(exclude=["test"]),
+    data_files=[
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="Foxpoint marinrobotik",
+    maintainer_email="foxpoint.se@gmail.com",
+    description="Simple fake-world simulation for local eel development.",
+    license="MIT",
+)

--- a/tests/test_depth_model.py
+++ b/tests/test_depth_model.py
@@ -1,0 +1,48 @@
+from math import radians, tan
+
+from eel_world_sim.depth_model import (
+    FLOAT_VELOCITY_MPS,
+    MAX_DEPTH_M,
+    MIN_DEPTH_M,
+    TERMINAL_VELOCITY_MPS,
+    DepthModel,
+)
+
+
+def test__when_dt_is_zero__should_not_change_depth() -> None:
+    model = DepthModel()
+    model.set_motor_cmd(1.0)
+    model.set_pitch_deg(45.0)
+    assert model.step(0.0) == 0.0
+
+
+def test__when_motor_idle__should_float_up_slowly() -> None:
+    model = DepthModel()
+    model.depth_m = 1.0
+    model.set_motor_cmd(0.0)
+    depth = model.step(1.0)
+    assert depth == 1.0 + FLOAT_VELOCITY_MPS
+
+
+def test__when_diving_nose_down__should_go_deeper() -> None:
+    model = DepthModel()
+    model.set_motor_cmd(1.0)
+    model.set_pitch_deg(45.0)
+    dive = tan(radians(45.0)) * TERMINAL_VELOCITY_MPS
+    expected = FLOAT_VELOCITY_MPS + dive
+    assert model.step(1.0) == expected
+
+
+def test__when_depth_would_exceed_max__should_cap() -> None:
+    model = DepthModel()
+    model.depth_m = MAX_DEPTH_M - 0.01
+    model.set_motor_cmd(1.0)
+    model.set_pitch_deg(80.0)
+    assert model.step(10.0) == MAX_DEPTH_M
+
+
+def test__when_depth_would_go_negative__should_cap_at_surface() -> None:
+    model = DepthModel()
+    model.depth_m = 0.01
+    model.set_motor_cmd(0.0)
+    assert model.step(10.0) == MIN_DEPTH_M

--- a/tests/test_depth_model.py
+++ b/tests/test_depth_model.py
@@ -1,4 +1,4 @@
-from math import radians, tan
+from math import isclose, radians, tan
 
 from eel_world_sim.depth_model import (
     FLOAT_VELOCITY_MPS,
@@ -21,7 +21,7 @@ def test__when_motor_idle__should_float_up_slowly() -> None:
     model.depth_m = 1.0
     model.set_motor_cmd(0.0)
     depth = model.step(1.0)
-    assert depth == 1.0 + FLOAT_VELOCITY_MPS
+    assert isclose(depth, 1.0 + FLOAT_VELOCITY_MPS)
 
 
 def test__when_diving_nose_down__should_go_deeper() -> None:
@@ -30,7 +30,7 @@ def test__when_diving_nose_down__should_go_deeper() -> None:
     model.set_pitch_deg(45.0)
     dive = tan(radians(45.0)) * TERMINAL_VELOCITY_MPS
     expected = FLOAT_VELOCITY_MPS + dive
-    assert model.step(1.0) == expected
+    assert isclose(model.step(1.0), expected)
 
 
 def test__when_depth_would_exceed_max__should_cap() -> None:


### PR DESCRIPTION
## Summary
- First slice of the world-sim / path-3 work stacked toward integration branch `world-sim` (not `main`, so no release yet).
- Adds `eel_world_sim` depth plant, `pressure_hardware` raw depth publisher, and `pressure_new` (status from `pressure/depth_m`). Old `pressure` bringup unchanged.
- Temporary goals doc for the iteration; clean up parallel leftovers before merging to `main`.

## Test plan
- [x] `source source_me.sh && make test`
- [ ] Manually: `pressure_hardware` or remapped plant + `pressure_new` publish `pressure/status`
- [ ] Do not merge this to `main` until the full path is proven