### PR TITLE
chore: close #227 with scoped pure-logic extractions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ Name: `test__when_<condition>__should_<outcome>` (double underscores).
 
 Prefer **pure unit tests** — extract logic from ROS callbacks/nodes into small functions, then test those. Don’t grow 50-line tests full of mocks; refactor production code until each test is ~10 lines: setup (helpers ok), act, assert.
 
+Reference: `navigation_goal_admission.py` + `navigation_goal_admission_test.py` (extract a pure helper, wire the node to call it, test reject/accept cases with `test__when_*__should_*` names).
+
 ## Typing
 
 Strict mypy runs on the file list in `pyproject.toml` (`make typecheck`, part of `make test`). Grow that list as files are clean.

--- a/src/eel/eel/modem/modem_hardware_node.py
+++ b/src/eel/eel/modem/modem_hardware_node.py
@@ -9,6 +9,7 @@ from eel_interfaces.msg import ModemRaw
 
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import MODEM_RAW
+from .modem_logic import modem_readings
 from .modem_sensor import ModemSensor
 
 PUBLISH_PERIOD_S = 2.0
@@ -30,8 +31,10 @@ class ModemHardwareNode(Node):
     def _publish_raw(self) -> None:
         reg_status = self._sensor.get_registration_status()
         signal_strength = self._sensor.get_received_signal_strength_indicator()
-        if reg_status is None or signal_strength is None:
+        readings = modem_readings(reg_status, signal_strength)
+        if readings is None:
             return
+        reg_status, signal_strength = readings
         out = ModemRaw()
         out.reg_status = reg_status
         out.signal_strength = signal_strength

--- a/src/eel/eel/modem/modem_logic.py
+++ b/src/eel/eel/modem/modem_logic.py
@@ -1,0 +1,19 @@
+def modem_readings(reg_status: int | None, signal_strength: int | None) -> tuple[int, int] | None:
+    if reg_status is None or signal_strength is None:
+        return None
+    return reg_status, signal_strength
+
+
+def has_modem_readings(reg_status: int | None, signal_strength: int | None) -> bool:
+    return modem_readings(reg_status, signal_strength) is not None
+
+
+def modem_connectivity(
+    reg_status: int,
+    signal_strength: int,
+    ping_ok: bool,
+    *,
+    min_signal_strength: int = 10,
+) -> bool:
+    registered = reg_status == 1 and signal_strength > min_signal_strength
+    return ping_ok if registered else False

--- a/src/eel/eel/modem/modem_node.py
+++ b/src/eel/eel/modem/modem_node.py
@@ -13,6 +13,7 @@ from eel_interfaces.msg import ModemRaw, ModemStatus
 
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import MODEM_RAW, MODEM_STATUS
+from .modem_logic import modem_connectivity
 from .modem_ping import http_ping
 
 PING_INTERVAL_SEC = 15.0
@@ -39,8 +40,7 @@ class ModemNode(Node):
     def _handle_raw(self, msg: ModemRaw) -> None:
         reg_status = int(msg.reg_status)
         signal_strength = int(msg.signal_strength)
-        check_connectivity = reg_status == 1 and signal_strength > 10
-        connectivity = self._cached_connectivity if check_connectivity else False
+        connectivity = modem_connectivity(reg_status, signal_strength, self._cached_connectivity)
 
         out = ModemStatus()
         out.reg_status = reg_status

--- a/src/eel/eel/navigation/navigation_action_server.py
+++ b/src/eel/eel/navigation/navigation_action_server.py
@@ -16,6 +16,7 @@ from std_msgs.msg import Float32
 from eel_interfaces.action import Navigate
 from eel_interfaces.msg import Coordinate, DepthControlCmd, ImuStatus, PressureStatus
 
+from ..utils.actuator_bounds import is_valid_coordinate
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import (
     DEPTH_CONTROL_CMD,
@@ -27,6 +28,7 @@ from ..utils.topics import (
 )
 from .assignments import Assignment, SurfaceAssignment, WaypointAndDepth
 from .common import LatLon, get_2d_distance
+from .navigation_goal_admission import NavigateGoalDecision, evaluate_navigate_goal
 from .navigation_pose import has_navigation_pose
 
 if TYPE_CHECKING:
@@ -117,39 +119,59 @@ class NavigationActionServer(Node):
 
     def goal_callback(self, goal_request: Navigate.Goal) -> GoalResponse:
         with self._goal_lock:
-            if self._goal_in_progress:
-                self.logger.info("Goal in progress. Rejecting new goal.")
-                return GoalResponse.REJECT
+            goal_in_progress = self._goal_in_progress
 
-        if not has_navigation_pose(self.current_position):
-            self.logger.info("No gps position has been acquired yet, rejecting goal.")
+        if goal_in_progress:
+            self.logger.info("Goal in progress. Rejecting new goal.")
             return GoalResponse.REJECT
 
-        distance_to_target = get_2d_distance(
-            pos1=LatLon(lat=self.current_position.lat, lon=self.current_position.lon),
-            pos2=LatLon(
-                lat=goal_request.goal.lat,
-                lon=goal_request.goal.lon,
-            ),
-        )
+        current_position = self.current_position
+        pose = current_position if has_navigation_pose(current_position) else None
+        coordinates_valid = False
+        distance_to_target = 0.0
+        if pose is not None:
+            coordinates_valid = is_valid_coordinate(pose.lat, pose.lon) and is_valid_coordinate(
+                goal_request.goal.lat,
+                goal_request.goal.lon,
+            )
+            if coordinates_valid:
+                distance_to_target = get_2d_distance(
+                    pos1=LatLon(lat=pose.lat, lon=pose.lon),
+                    pos2=LatLon(
+                        lat=goal_request.goal.lat,
+                        lon=goal_request.goal.lon,
+                    ),
+                )
 
-        # Simple sanity check that the target is not to far away, could be removed
-        if distance_to_target < TARGET_DISTANCE_LIMIT:
-            with self._goal_lock:
-                if self._goal_in_progress:
-                    self.logger.info("Goal in progress. Rejecting new goal.")
-                    return GoalResponse.REJECT
-                self._goal_in_progress = True
-            self.logger.info(f"Accepted new target, lat: {goal_request.goal.lat} lon: {goal_request.goal.lon}")
-            self.logger.info(f"Distance to new target: {distance_to_target}m")
-            return GoalResponse.ACCEPT
-        else:
+        decision = evaluate_navigate_goal(
+            goal_in_progress=False,
+            has_pose=pose is not None,
+            coordinates_valid=coordinates_valid,
+            distance_to_target_m=distance_to_target,
+            distance_limit_m=TARGET_DISTANCE_LIMIT,
+        )
+        if decision is NavigateGoalDecision.REJECT_NO_POSE:
+            self.logger.info("No gps position has been acquired yet, rejecting goal.")
+            return GoalResponse.REJECT
+        if decision is NavigateGoalDecision.REJECT_INVALID_COORDINATES:
+            self.logger.info("Invalid navigation coordinates, rejecting goal.")
+            return GoalResponse.REJECT
+        if decision is NavigateGoalDecision.REJECT_TOO_FAR:
             self.logger.info(
                 f"Goal rejected - Distance to target {distance_to_target} is larger "
                 f"than set limit {TARGET_DISTANCE_LIMIT}"
             )
-
             return GoalResponse.REJECT
+
+        with self._goal_lock:
+            if self._goal_in_progress:
+                self.logger.info("Goal in progress. Rejecting new goal.")
+                return GoalResponse.REJECT
+            self._goal_in_progress = True
+
+        self.logger.info(f"Accepted new target, lat: {goal_request.goal.lat} lon: {goal_request.goal.lon}")
+        self.logger.info(f"Distance to new target: {distance_to_target}m")
+        return GoalResponse.ACCEPT
 
     def cancel_callback(self, goal_handle: NavigateGoalHandle) -> CancelResponse:
         self.logger.info("Goal cancel request received, turning off motors.")

--- a/src/eel/eel/navigation/navigation_goal_admission.py
+++ b/src/eel/eel/navigation/navigation_goal_admission.py
@@ -1,0 +1,29 @@
+import math
+from enum import Enum
+
+
+class NavigateGoalDecision(Enum):
+    ACCEPT = "accept"
+    REJECT_BUSY = "reject_busy"
+    REJECT_NO_POSE = "reject_no_pose"
+    REJECT_INVALID_COORDINATES = "reject_invalid_coordinates"
+    REJECT_TOO_FAR = "reject_too_far"
+
+
+def evaluate_navigate_goal(
+    *,
+    goal_in_progress: bool,
+    has_pose: bool,
+    coordinates_valid: bool,
+    distance_to_target_m: float,
+    distance_limit_m: float,
+) -> NavigateGoalDecision:
+    if goal_in_progress:
+        return NavigateGoalDecision.REJECT_BUSY
+    if not has_pose:
+        return NavigateGoalDecision.REJECT_NO_POSE
+    if not coordinates_valid:
+        return NavigateGoalDecision.REJECT_INVALID_COORDINATES
+    if not math.isfinite(distance_to_target_m) or distance_to_target_m >= distance_limit_m:
+        return NavigateGoalDecision.REJECT_TOO_FAR
+    return NavigateGoalDecision.ACCEPT

--- a/src/eel/eel/pressure/pressure_hardware_node.py
+++ b/src/eel/eel/pressure/pressure_hardware_node.py
@@ -9,6 +9,7 @@ from std_msgs.msg import Float32
 
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import PRESSURE_DEPTH_M
+from .pressure_math import has_depth_sample
 from .pressure_serial_driver import PressureSerialDriver
 
 PUBLISH_HZ = 5.0
@@ -30,7 +31,7 @@ class PressureHardwareNode(Node):
 
     def _publish_depth(self) -> None:
         depth_m = self._driver.get_depth_m()
-        if depth_m is None:
+        if not has_depth_sample(depth_m):
             return
         if self._driver.is_calibrated and not self._logged_calibration:
             self.get_logger().info("Atmosphere offset set from first sample")

--- a/src/eel/eel/pressure/pressure_math.py
+++ b/src/eel/eel/pressure/pressure_math.py
@@ -1,6 +1,14 @@
 """Pure depth helpers for pressure app logic (no ROS)."""
 
 import math
+from typing import TypeGuard
+
+
+def has_depth_sample(depth_m: float | None) -> TypeGuard[float]:
+    """True when a depth reading is present, including 0.0 at the surface."""
+    if depth_m is None:
+        return False
+    return math.isfinite(depth_m)
 
 
 def calculate_center_depth(main_depth: float, pitch_deg: float, displacement: float = 0.375) -> float:

--- a/src/eel/eel/pressure/pressure_node.py
+++ b/src/eel/eel/pressure/pressure_node.py
@@ -11,7 +11,7 @@ from eel_interfaces.msg import ImuStatus, PressureStatus
 
 from ..utils.node_runner import spin_node_until_shutdown
 from ..utils.topics import IMU_STATUS, PRESSURE_DEPTH_M, PRESSURE_STATUS
-from .pressure_math import calculate_center_depth, get_depth_velocity
+from .pressure_math import calculate_center_depth, get_depth_velocity, has_depth_sample
 
 PUBLISH_HZ = 5.0
 
@@ -39,10 +39,11 @@ class PressureNode(Node):
         self._pitch_deg = float(msg.pitch)
 
     def _publish_status(self) -> None:
-        if self._sensor_depth_m is None:
+        sensor_depth_m = self._sensor_depth_m
+        if not has_depth_sample(sensor_depth_m):
             return
 
-        center_depth_m = calculate_center_depth(self._sensor_depth_m, self._pitch_deg)
+        center_depth_m = calculate_center_depth(sensor_depth_m, self._pitch_deg)
         now = time()
         depth_velocity = get_depth_velocity(
             center_depth_m,

--- a/src/eel/eel/pressure/pressure_serial_driver.py
+++ b/src/eel/eel/pressure/pressure_serial_driver.py
@@ -2,6 +2,7 @@
 
 import serial
 
+from .pressure_math import has_depth_sample
 from .pressure_serial_frames import FLOAT32_SIZE, take_float32_le
 
 
@@ -21,7 +22,7 @@ class PressureSerialDriver:
     def get_depth_m(self) -> float | None:
         """Depth in meters relative to the first good sample (surface offset)."""
         sample_m = self._read_depth_sample()
-        if sample_m is None:
+        if not has_depth_sample(sample_m):
             return None
         if self._atmosphere_offset_m is None:
             self._atmosphere_offset_m = sample_m

--- a/src/eel/test/eel/modem/modem_logic_test.py
+++ b/src/eel/test/eel/modem/modem_logic_test.py
@@ -1,0 +1,27 @@
+from eel.modem.modem_logic import has_modem_readings, modem_connectivity
+
+
+def test__when_readings_missing__should_not_have_modem_readings() -> None:
+    assert not has_modem_readings(None, 20)
+    assert not has_modem_readings(1, None)
+
+
+def test__when_readings_present_including_zero__should_have_modem_readings() -> None:
+    assert has_modem_readings(0, 0)
+    assert has_modem_readings(1, 15)
+
+
+def test__when_not_registered__should_not_report_connectivity() -> None:
+    assert not modem_connectivity(reg_status=0, signal_strength=20, ping_ok=True)
+
+
+def test__when_registered_but_signal_weak__should_not_report_connectivity() -> None:
+    assert not modem_connectivity(reg_status=1, signal_strength=10, ping_ok=True)
+
+
+def test__when_registered_and_ping_ok__should_report_connectivity() -> None:
+    assert modem_connectivity(reg_status=1, signal_strength=11, ping_ok=True)
+
+
+def test__when_registered_but_ping_fails__should_not_report_connectivity() -> None:
+    assert not modem_connectivity(reg_status=1, signal_strength=11, ping_ok=False)

--- a/src/eel/test/eel/navigation/navigation_goal_admission_test.py
+++ b/src/eel/test/eel/navigation/navigation_goal_admission_test.py
@@ -1,0 +1,81 @@
+from eel.navigation.navigation_goal_admission import NavigateGoalDecision, evaluate_navigate_goal
+
+DISTANCE_LIMIT_M = 2500.0
+
+
+def test__when_goal_in_progress__should_reject_busy() -> None:
+    assert (
+        evaluate_navigate_goal(
+            goal_in_progress=True,
+            has_pose=True,
+            coordinates_valid=True,
+            distance_to_target_m=100.0,
+            distance_limit_m=DISTANCE_LIMIT_M,
+        )
+        == NavigateGoalDecision.REJECT_BUSY
+    )
+
+
+def test__when_pose_missing__should_reject_no_pose() -> None:
+    assert (
+        evaluate_navigate_goal(
+            goal_in_progress=False,
+            has_pose=False,
+            coordinates_valid=False,
+            distance_to_target_m=100.0,
+            distance_limit_m=DISTANCE_LIMIT_M,
+        )
+        == NavigateGoalDecision.REJECT_NO_POSE
+    )
+
+
+def test__when_coordinates_invalid__should_reject() -> None:
+    assert (
+        evaluate_navigate_goal(
+            goal_in_progress=False,
+            has_pose=True,
+            coordinates_valid=False,
+            distance_to_target_m=100.0,
+            distance_limit_m=DISTANCE_LIMIT_M,
+        )
+        == NavigateGoalDecision.REJECT_INVALID_COORDINATES
+    )
+
+
+def test__when_target_too_far__should_reject_distance() -> None:
+    assert (
+        evaluate_navigate_goal(
+            goal_in_progress=False,
+            has_pose=True,
+            coordinates_valid=True,
+            distance_to_target_m=DISTANCE_LIMIT_M,
+            distance_limit_m=DISTANCE_LIMIT_M,
+        )
+        == NavigateGoalDecision.REJECT_TOO_FAR
+    )
+
+
+def test__when_pose_ok_and_target_near__should_accept() -> None:
+    assert (
+        evaluate_navigate_goal(
+            goal_in_progress=False,
+            has_pose=True,
+            coordinates_valid=True,
+            distance_to_target_m=100.0,
+            distance_limit_m=DISTANCE_LIMIT_M,
+        )
+        == NavigateGoalDecision.ACCEPT
+    )
+
+
+def test__when_distance_is_nan__should_reject() -> None:
+    assert (
+        evaluate_navigate_goal(
+            goal_in_progress=False,
+            has_pose=True,
+            coordinates_valid=True,
+            distance_to_target_m=float("nan"),
+            distance_limit_m=DISTANCE_LIMIT_M,
+        )
+        == NavigateGoalDecision.REJECT_TOO_FAR
+    )

--- a/src/eel/test/eel/pressure/pressure_math_test.py
+++ b/src/eel/test/eel/pressure/pressure_math_test.py
@@ -1,6 +1,6 @@
 import math
 
-from eel.pressure.pressure_math import calculate_center_depth, get_depth_velocity
+from eel.pressure.pressure_math import calculate_center_depth, get_depth_velocity, has_depth_sample
 
 
 def test__when_pitch_is_zero__should_return_sensor_depth() -> None:
@@ -26,3 +26,15 @@ def test__when_time_delta_is_zero__should_report_zero_velocity() -> None:
 
 def test__when_clock_goes_backwards__should_report_zero_velocity() -> None:
     assert get_depth_velocity(2.0, previous_depth=1.0, now=0.5, previous_depth_at=1.0) == 0.0
+
+
+def test__when_depth_is_zero__should_count_as_present_sample() -> None:
+    assert has_depth_sample(0.0)
+
+
+def test__when_depth_is_missing__should_not_count_as_present_sample() -> None:
+    assert not has_depth_sample(None)
+
+
+def test__when_depth_is_nan__should_not_count_as_present_sample() -> None:
+    assert not has_depth_sample(float("nan"))

--- a/src/eel/test/eel/pressure/pressure_serial_driver_test.py
+++ b/src/eel/test/eel/pressure/pressure_serial_driver_test.py
@@ -1,0 +1,19 @@
+from unittest.mock import MagicMock, patch
+
+from eel.pressure.pressure_serial_driver import PressureSerialDriver
+
+
+@patch("eel.pressure.pressure_serial_driver.serial.Serial")
+def test__when_first_frame_is_nan__should_not_calibrate(_serial: MagicMock) -> None:
+    driver = PressureSerialDriver("/dev/ttyUSB0")
+    driver._read_depth_sample = MagicMock(return_value=float("nan"))
+
+    assert driver.get_depth_m() is None
+    assert not driver.is_calibrated
+
+    driver._read_depth_sample.return_value = 2.0
+    assert driver.get_depth_m() == 0.0
+    assert driver.is_calibrated
+
+    driver._read_depth_sample.return_value = 2.5
+    assert driver.get_depth_m() == 0.5


### PR DESCRIPTION
## Summary
- Extract and unit-test navigate goal admission (busy, no pose, too far, accept).
- Extract and unit-test modem reading presence and connectivity rules.
- Add `has_depth_sample` so 0.0 m surface depth is treated as valid (#199 class).
- Document the extract-and-test pattern in AGENTS.md (nav admission as reference).

Closes #227 with agreed scope. Dive cancel/succeed was intentionally skipped — too trivial to extract.

## Test plan
- [x] `source source_me.sh && make test`